### PR TITLE
Tighten banked time report for mobile

### DIFF
--- a/reports/banked_time.html
+++ b/reports/banked_time.html
@@ -38,24 +38,6 @@
             margin-bottom: 10px;
         }
 
-        @media (max-width: 600px) {
-            .header {
-                padding: 20px;
-            }
-            .header h1 {
-                font-size: 1.8em;
-            }
-            .header p {
-                font-size: 0.9em;
-            }
-            .section {
-                padding: 15px;
-            }
-            .section h3 {
-                font-size: 1.2em;
-            }
-        }
-
         .back-button {
             display: inline-block;
             margin-top: 20px;
@@ -94,12 +76,6 @@
             margin-top: 20px;
         }
 
-        @media (max-width: 600px) {
-            .kids-grid {
-                grid-template-columns: 1fr;
-            }
-        }
-
         .kid-card {
             background: #f8f9fa;
             border-radius: 8px;
@@ -126,17 +102,6 @@
             border-left: 4px solid #FF6B6B;
             flex-wrap: wrap;
             gap: 10px;
-        }
-
-        @media (max-width: 600px) {
-            .info-row {
-                padding: 12px;
-                flex-direction: column;
-                align-items: flex-start;
-            }
-            .info-label {
-                font-size: 0.9em;
-            }
         }
 
         .info-label {
@@ -169,15 +134,6 @@
             color: #666;
         }
 
-        @media (max-width: 600px) {
-            .info-value.date {
-                font-size: 0.75em;
-            }
-            .info-value.banked-time {
-                font-size: 1.2em;
-            }
-        }
-
         .edit-input {
             font-size: 1.5em;
             font-weight: bold;
@@ -187,13 +143,6 @@
             padding: 5px 10px;
             width: 120px;
             text-align: center;
-        }
-
-        @media (max-width: 600px) {
-            .edit-input {
-                font-size: 1.2em;
-                width: 100px;
-            }
         }
 
         .save-button {
@@ -248,6 +197,7 @@
             display: flex;
             align-items: center;
             gap: 5px;
+            flex-wrap: wrap;
         }
 
         .loading {
@@ -264,6 +214,128 @@
             padding: 20px;
             color: #c62828;
             margin: 20px 0;
+        }
+
+        /* Condensed mobile layout */
+        @media (max-width: 600px) {
+            body {
+                padding: 10px;
+                line-height: 1.4;
+            }
+
+            .header {
+                padding: 12px 14px;
+                margin-bottom: 12px;
+                border-radius: 8px;
+            }
+
+            .header h1 {
+                font-size: 1.35em;
+                margin-bottom: 4px;
+            }
+
+            .header p {
+                font-size: 0.8em;
+                margin: 0;
+            }
+
+            .back-button {
+                margin-top: 10px;
+                padding: 6px 12px;
+                font-size: 0.85em;
+            }
+
+            .section {
+                margin: 10px 0;
+                padding: 12px;
+                border-radius: 8px;
+            }
+
+            .section h3 {
+                font-size: 1.05em;
+                margin-bottom: 10px;
+                padding-bottom: 6px;
+            }
+
+            .kids-grid {
+                grid-template-columns: 1fr;
+                gap: 10px;
+                margin-top: 10px;
+            }
+
+            .kid-card {
+                padding: 10px 12px;
+                border-width: 1px;
+                border-radius: 6px;
+            }
+
+            .kid-card h4 {
+                font-size: 1.1em;
+                margin-bottom: 8px;
+                padding-bottom: 4px;
+            }
+
+            .info-row {
+                padding: 8px 10px;
+                margin: 6px 0;
+                gap: 6px;
+                border-radius: 6px;
+                border-left-width: 3px;
+                /* Keep horizontal to stay compact */
+                flex-direction: row;
+                align-items: center;
+                flex-wrap: wrap;
+            }
+
+            .info-label {
+                font-size: 0.8em;
+                flex-shrink: 0;
+            }
+
+            .info-value {
+                font-size: 1em;
+                text-align: right;
+            }
+
+            .info-value.banked-time {
+                font-size: 1.1em;
+                padding: 2px 6px;
+            }
+
+            .info-value.date {
+                font-size: 0.72em;
+                white-space: nowrap;
+            }
+
+            .edit-input {
+                font-size: 1em;
+                width: 72px;
+                padding: 4px 6px;
+            }
+
+            .save-button,
+            .cancel-button,
+            .danger-button {
+                padding: 6px 10px;
+                font-size: 0.8em;
+                margin-left: 0;
+            }
+
+            .edit-container {
+                gap: 4px;
+                justify-content: flex-end;
+            }
+
+            .loading {
+                padding: 24px 12px;
+                font-size: 1em;
+            }
+
+            .error {
+                padding: 12px;
+                margin: 10px 0;
+                font-size: 0.9em;
+            }
         }
     </style>
 </head>
@@ -388,15 +460,15 @@
             card.innerHTML = `
                 <h4>${kidName}</h4>
                 <div class="info-row">
-                    <span class="info-label">Banked Time:</span>
+                    <span class="info-label">Banked:</span>
                     <span id="${bankedTimeId}" class="info-value banked-time" onclick="editBankedTime('${kidData.kid}', ${kidData.bankedMins})">${kidData.bankedMins} minutes</span>
                 </div>
                 <div class="info-row">
-                    <span class="info-label">Reward Session:</span>
-                    <button class="danger-button" onclick="expireRewardTime('${kidData.kid}')">Expire Reward Time</button>
+                    <span class="info-label">Reward:</span>
+                    <button class="danger-button" onclick="expireRewardTime('${kidData.kid}')">Expire</button>
                 </div>
                 <div class="info-row">
-                    <span class="info-label">Last Updated:</span>
+                    <span class="info-label">Updated:</span>
                     <span class="info-value date">${formatTimestamp(kidData.lastUpdated)}</span>
                 </div>
             `;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Makes the Banked Time report more condensed on small screens so both kid cards fit with less scrolling.

## Changes
- Consolidated mobile CSS (`max-width: 600px`) with tighter body/header/section/card padding and smaller type
- Kept info rows horizontal instead of stacking vertically (previous mobile styles used more vertical space)
- Shortened labels/button text (`Banked`, `Reward` / `Expire`, `Updated`) for narrow widths
- Compacted edit controls and action buttons on mobile

Desktop layout is unchanged aside from the shorter shared labels.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcec1-31a5-7ab3-85ed-db6dcb74b522?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcec1-31a5-7ab3-85ed-db6dcb74b522&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

