### PR TITLE
Photo chores on the trainer map with parent cash review

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -104,6 +104,11 @@
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
         <activity
+            android:name=".ChorePhotoActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
+        <activity
             android:name=".TrainingMapActivity"
             android:exported="false"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"

--- a/app/src/main/assets/config/AM_config.json
+++ b/app/src/main/assets/config/AM_config.json
@@ -1053,6 +1053,164 @@
             ],
             "title": "Bonus Games",
             "description": "Just for fun!"
+        },
+        {
+            "id": "chores",
+            "title": "Daily Chores",
+            "tasks": [
+                {
+                    "id": "wash_laundry",
+                    "title": "Wash laundry",
+                    "description": "Start a load of laundry in the washer.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,thu",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "dry_laundry",
+                    "title": "Dry laundry",
+                    "description": "Move laundry to the dryer and start it.",
+                    "rewardCash": 1.0,
+                    "displayDays": "tue,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "put_away_laundry",
+                    "title": "Put away laundry",
+                    "description": "Fold and put away the clean laundry.",
+                    "rewardCash": 2.0,
+                    "displayDays": "wed,sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "take_out_trash",
+                    "title": "Take out trash",
+                    "description": "Take the trash to the outside bin.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,thu",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "take_out_recycling",
+                    "title": "Take out recycling",
+                    "description": "Take recycling to the outside bin.",
+                    "rewardCash": 1.0,
+                    "displayDays": "tue,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "pack_school_bag",
+                    "title": "Pack school bag",
+                    "description": "Pack your school bag for tomorrow.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,tue,wed,thu,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "make_own_breakfast",
+                    "title": "Make own breakfast",
+                    "description": "Make your own breakfast.",
+                    "rewardCash": 1.0,
+                    "displayDays": "sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "make_own_lunch",
+                    "title": "Make own lunch",
+                    "description": "Make your own lunch.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_up_table",
+                    "title": "Clean up table",
+                    "description": "Clean up the table and wipe it clean.",
+                    "rewardCash": 2.0,
+                    "displayDays": "mon,wed,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_kitchen_counter",
+                    "title": "Clean kitchen counter",
+                    "description": "Clean up the kitchen counter and wipe it clean.",
+                    "rewardCash": 2.0,
+                    "displayDays": "tue,thu,sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "tidy_coffee_table",
+                    "title": "Tidy living room tops",
+                    "description": "Tidy the coffee table, toy chest and dresser top.",
+                    "rewardCash": 2.0,
+                    "displayDays": "thu,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_bathroom_counter",
+                    "title": "Clean bathroom counter",
+                    "description": "Clean the warm bathroom counter and wipe it clean.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "unload_dishwasher",
+                    "title": "Unload dishwasher",
+                    "description": "Unload the dishwasher and put everything away.",
+                    "rewardCash": 2.0,
+                    "displayDays": "mon,wed,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "feed_dog",
+                    "title": "Feed the dog",
+                    "description": "Feed the dog and give water if needed.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,tue,wed,thu,fri,sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_room",
+                    "title": "Clean your room",
+                    "description": "Organize your room: tidy floor and desk/dresser tops. Do not shove everything in a drawer.",
+                    "rewardCash": 2.0,
+                    "displayDays": "wed,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "tidy_toys_basement",
+                    "title": "Tidy basement toys",
+                    "description": "Tidy toys in the basement.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "dust_windows_basement",
+                    "title": "Dust basement windows",
+                    "description": "Dust the windows in the basement.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "dust_stairway",
+                    "title": "Dust stairway",
+                    "description": "Dust the stairway.",
+                    "rewardCash": 1.0,
+                    "displayDays": "wed",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "tidy_laundry_room",
+                    "title": "Tidy laundry room",
+                    "description": "Tidy the laundry room bench and boot tray; hang up jackets, pants, mittens and hats in bins.",
+                    "rewardCash": 1.0,
+                    "displayDays": "fri",
+                    "launch": "chorePhoto"
+                }
+            ]
         }
     ]
 }

--- a/app/src/main/assets/config/BM_config.json
+++ b/app/src/main/assets/config/BM_config.json
@@ -3,7 +3,7 @@
     "header": {
         "buttons": [
             {
-                "label": "⚡ Battle Hub",
+                "label": "\u26a1 Battle Hub",
                 "action": "openBattleHub"
             },
             {
@@ -1038,6 +1038,180 @@
             ],
             "title": "Bonus Games",
             "description": "Just for fun!"
+        },
+        {
+            "id": "chores",
+            "title": "Daily Chores",
+            "tasks": [
+                {
+                    "id": "wash_laundry",
+                    "title": "Wash laundry",
+                    "description": "Start a load of laundry in the washer.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,thu",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "dry_laundry",
+                    "title": "Dry laundry",
+                    "description": "Move laundry to the dryer and start it.",
+                    "rewardCash": 1.0,
+                    "displayDays": "tue,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "put_away_laundry",
+                    "title": "Put away laundry",
+                    "description": "Fold and put away the clean laundry.",
+                    "rewardCash": 2.0,
+                    "displayDays": "wed,sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "take_out_trash",
+                    "title": "Take out trash",
+                    "description": "Take the trash to the outside bin.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,thu",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "take_out_recycling",
+                    "title": "Take out recycling",
+                    "description": "Take recycling to the outside bin.",
+                    "rewardCash": 1.0,
+                    "displayDays": "tue,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "pack_school_bag",
+                    "title": "Pack school bag",
+                    "description": "Pack your school bag for tomorrow.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,tue,wed,thu,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "help_amren_homework",
+                    "title": "Help Amren with homework",
+                    "description": "Help Amren with homework.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,wed,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "make_own_breakfast",
+                    "title": "Make own breakfast",
+                    "description": "Make your own breakfast.",
+                    "rewardCash": 1.0,
+                    "displayDays": "sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "make_sibling_breakfast",
+                    "title": "Make sibling breakfast",
+                    "description": "Make sibling's breakfast if they agree to what you make.",
+                    "rewardCash": 1.0,
+                    "displayDays": "sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "make_own_lunch",
+                    "title": "Make own lunch",
+                    "description": "Make your own lunch.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_up_table",
+                    "title": "Clean up table",
+                    "description": "Clean up the table and wipe it clean.",
+                    "rewardCash": 2.0,
+                    "displayDays": "mon,wed,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_kitchen_counter",
+                    "title": "Clean kitchen counter",
+                    "description": "Clean up the kitchen counter and wipe it clean.",
+                    "rewardCash": 2.0,
+                    "displayDays": "tue,thu,sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "tidy_coffee_table",
+                    "title": "Tidy living room tops",
+                    "description": "Tidy the coffee table, toy chest and dresser top.",
+                    "rewardCash": 2.0,
+                    "displayDays": "thu,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_bathroom_counter",
+                    "title": "Clean bathroom counter",
+                    "description": "Clean the warm bathroom counter and wipe it clean.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "unload_dishwasher",
+                    "title": "Unload dishwasher",
+                    "description": "Unload the dishwasher and put everything away.",
+                    "rewardCash": 2.0,
+                    "displayDays": "mon,wed,fri",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "feed_dog",
+                    "title": "Feed the dog",
+                    "description": "Feed the dog and give water if needed.",
+                    "rewardCash": 1.0,
+                    "displayDays": "mon,tue,wed,thu,fri,sat,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "clean_room",
+                    "title": "Clean your room",
+                    "description": "Organize your room: tidy floor and desk/dresser tops. Do not shove everything in a drawer.",
+                    "rewardCash": 2.0,
+                    "displayDays": "wed,sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "tidy_toys_basement",
+                    "title": "Tidy basement toys",
+                    "description": "Tidy toys in the basement.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sat",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "dust_windows_basement",
+                    "title": "Dust basement windows",
+                    "description": "Dust the windows in the basement.",
+                    "rewardCash": 2.0,
+                    "displayDays": "sun",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "dust_stairway",
+                    "title": "Dust stairway",
+                    "description": "Dust the stairway.",
+                    "rewardCash": 1.0,
+                    "displayDays": "wed",
+                    "launch": "chorePhoto"
+                },
+                {
+                    "id": "tidy_laundry_room",
+                    "title": "Tidy laundry room",
+                    "description": "Tidy the laundry room bench and boot tray; hang up jackets, pants, mittens and hats in bins.",
+                    "rewardCash": 1.0,
+                    "displayDays": "fri",
+                    "launch": "chorePhoto"
+                }
+            ]
         }
     ]
 }

--- a/app/src/main/assets/config/TE_config.json
+++ b/app/src/main/assets/config/TE_config.json
@@ -466,6 +466,27 @@
                     "launch": "translation",
                     "disable": "Dec 31, 2099",
                     "totalQuestions": 5
+                },
+                {
+                    "stars": 1,
+                    "title": "Make bed",
+                    "launch": "choreMakeBed",
+                    "webGame": true,
+                    "url": "https://talq2me.github.io/BaerenEd-Android-App/app/src/main/assets/html/chorePhoto.html?choreId=make_bed&title=Make%20bed&description=Make%20your%20bed%20neatly.&rewardCash=1"
+                },
+                {
+                    "stars": 1,
+                    "title": "Unload dishwasher",
+                    "launch": "choreUnloadDishwasher",
+                    "webGame": true,
+                    "url": "https://talq2me.github.io/BaerenEd-Android-App/app/src/main/assets/html/chorePhoto.html?choreId=unload_dishwasher&title=Unload%20dishwasher&description=Unload%20the%20dishwasher%20and%20put%20everything%20away.&rewardCash=2"
+                },
+                {
+                    "stars": 1,
+                    "title": "Take out trash",
+                    "launch": "choreTakeOutTrash",
+                    "webGame": true,
+                    "url": "https://talq2me.github.io/BaerenEd-Android-App/app/src/main/assets/html/chorePhoto.html?choreId=take_out_trash&title=Take%20out%20trash&description=Take%20the%20trash%20to%20the%20outside%20bin.&rewardCash=3"
                 }
             ],
             "title": "Required Tasks",

--- a/app/src/main/assets/html/chorePhoto.html
+++ b/app/src/main/assets/html/chorePhoto.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Photo Chore</title>
+    <style>
+        body {
+            font-family: 'Comic Sans MS', 'Chalkboard', 'Arial Rounded MT Bold', sans-serif;
+            background-color: #fffcf9;
+            text-align: center;
+            margin: 0;
+            padding: 0;
+        }
+        .game-container {
+            width: 100%;
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        h1 {
+            color: #2e7d32;
+            margin-bottom: 8px;
+        }
+        .description {
+            font-size: 18px;
+            color: #444;
+            margin: 12px 0 8px;
+        }
+        .reward {
+            font-size: 16px;
+            color: #666;
+            margin-bottom: 20px;
+        }
+        .button, .green-button, .camera-button {
+            font-family: inherit;
+            border: none;
+            border-radius: 15px;
+            cursor: pointer;
+            display: inline-block;
+            text-align: center;
+            transition: background-color 0.3s, transform 0.2s;
+            box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+            margin: 4px 8px 4px 0;
+            padding: 15px 30px;
+            font-size: 20px;
+            color: white;
+        }
+        .button { background-color: #6ac2ff; }
+        .green-button { background-color: #4CAF50; }
+        .camera-button {
+            background-color: #ff6b6b;
+            font-size: 24px;
+            padding: 20px 40px;
+            margin: 20px 0;
+        }
+        .button:hover, .green-button:hover, .camera-button:hover {
+            background-color: #ff8c00;
+            transform: scale(1.05);
+        }
+        .button:disabled, .green-button:disabled, .camera-button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+        }
+        .hidden { display: none; }
+        .camera-container {
+            margin: 20px 0;
+            padding: 20px;
+            background: #fff3cd;
+            border-radius: 10px;
+            border: 2px solid #ffeaa7;
+        }
+        .image-preview {
+            max-width: 100%;
+            max-height: 420px;
+            border-radius: 10px;
+            margin: 15px 0;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+        }
+        .upload-actions {
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+            margin-top: 15px;
+            flex-wrap: wrap;
+        }
+        .message {
+            padding: 15px;
+            margin: 15px 0;
+            border-radius: 8px;
+            font-size: 18px;
+            font-weight: bold;
+        }
+        .message.success {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .message.error {
+            background: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        .message.info {
+            background: #d1ecf1;
+            color: #0c5460;
+            border: 1px solid #bee5eb;
+        }
+        input[type="file"] { display: none; }
+    </style>
+</head>
+<body>
+    <div class="game-container">
+        <h1 id="choreTitle">Chore</h1>
+        <p class="description" id="choreDescription">Take a photo of the finished chore.</p>
+        <p class="reward" id="choreReward">Reward: $0 (parent reviews)</p>
+
+        <div>
+            <button class="camera-button" id="takePictureBtn" onclick="openCamera()">Take Photo</button>
+        </div>
+
+        <div class="camera-container hidden" id="cameraContainer">
+            <h3>Preview</h3>
+            <img id="imagePreview" class="image-preview" alt="Preview">
+            <div class="upload-actions">
+                <button class="button" id="retakeBtn" onclick="retakePhoto()">Retake</button>
+                <button class="green-button" id="doneBtn" onclick="submitPhoto()">Done</button>
+            </div>
+        </div>
+
+        <div id="messageContainer"></div>
+        <input type="file" id="cameraInput" accept="image/*" capture="environment">
+    </div>
+
+    <script>
+        /**
+         * Query params (from config url):
+         *   choreId      - required; used in image_uploads.task = chore_{id}_r{reward}_{yyyy-MM-dd}
+         *   title        - screen title (also map task title in config)
+         *   description  - instructions
+         *   rewardCash   - dollars for parent report grant default (e.g. 1 or 1.5)
+         */
+        let capturedImageBase64 = null;
+        let submitting = false;
+        let choreId = '';
+        let choreTitle = 'Chore';
+        let choreDescription = 'Take a photo of the finished chore.';
+        let rewardCash = 0;
+
+        function formatRewardCash(amount) {
+            const value = Number(amount) || 0;
+            if (Math.abs(value - Math.round(value)) < 0.001) {
+                return '$' + Math.round(value);
+            }
+            return '$' + value.toFixed(2);
+        }
+
+        /** America/Toronto calendar date as yyyy-MM-dd. */
+        function torontoDateYmd() {
+            return new Intl.DateTimeFormat('en-CA', {
+                timeZone: 'America/Toronto',
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit'
+            }).format(new Date());
+        }
+
+        /**
+         * Parent report parses: chore_{choreId}_r{reward}_{date}
+         * Reward is embedded so grant amount works without photo_chores DB rows.
+         */
+        function imageTaskKey(id, reward) {
+            const centsSafe = String(Number(reward) || 0);
+            return 'chore_' + id + '_r' + centsSafe + '_' + torontoDateYmd();
+        }
+
+        function readParams() {
+            const params = new URLSearchParams(window.location.search);
+            choreId = (params.get('choreId') || '').trim();
+            choreTitle = (params.get('title') || 'Chore').trim() || 'Chore';
+            choreDescription = (params.get('description') || '').trim()
+                || 'Take a photo of the finished chore.';
+            const rawReward = params.get('rewardCash');
+            rewardCash = rawReward != null && rawReward !== '' ? Number(rawReward) : 0;
+            if (Number.isNaN(rewardCash)) rewardCash = 0;
+        }
+
+        function applyUi() {
+            document.getElementById('choreTitle').textContent = choreTitle;
+            document.getElementById('choreDescription').textContent = choreDescription;
+            document.getElementById('choreReward').textContent =
+                'Reward: ' + formatRewardCash(rewardCash) + ' (parent reviews)';
+            if (!choreId) {
+                showMessage('This chore is missing choreId in the URL.', 'error');
+                document.getElementById('takePictureBtn').disabled = true;
+            }
+        }
+
+        function hideMessage() {
+            document.getElementById('messageContainer').innerHTML = '';
+        }
+
+        function showMessage(text, type) {
+            document.getElementById('messageContainer').innerHTML =
+                '<div class="message ' + (type || 'info') + '">' + text + '</div>';
+        }
+
+        function setBusy(busy) {
+            submitting = busy;
+            document.getElementById('takePictureBtn').disabled = busy;
+            document.getElementById('retakeBtn').disabled = busy;
+            document.getElementById('doneBtn').disabled = busy;
+        }
+
+        window.onCameraSuccess = function(imageBase64) {
+            if (imageBase64) {
+                capturedImageBase64 = imageBase64.startsWith('data:image')
+                    ? imageBase64
+                    : 'data:image/jpeg;base64,' + imageBase64;
+                document.getElementById('imagePreview').src = capturedImageBase64;
+                document.getElementById('cameraContainer').classList.remove('hidden');
+                document.getElementById('takePictureBtn').textContent = 'Retake photo';
+                hideMessage();
+            } else {
+                showMessage('No image captured. Please try again.', 'error');
+            }
+        };
+
+        window.onCameraError = function(error) {
+            showMessage('Failed to open camera. Please try again.', 'error');
+            console.error('Camera error:', error);
+        };
+
+        window.onUploadSuccess = function() {
+            showMessage('Photo submitted! Parent will review for the reward.', 'success');
+            // Complete like any other web game (marks the map task done).
+            if (window.Android && typeof window.Android.gameCompleted === 'function') {
+                try {
+                    window.Android.gameCompleted(1, 0);
+                } catch (e) {
+                    setBusy(false);
+                    showMessage('Photo saved but could not finish the task: ' + e.message, 'error');
+                }
+            } else {
+                setBusy(false);
+                showMessage('Photo saved. Close this screen when ready.', 'success');
+            }
+        };
+
+        window.onUploadError = function(error) {
+            setBusy(false);
+            showMessage('Could not save photo: ' + error, 'error');
+            console.error('Upload error:', error);
+        };
+
+        function openCamera() {
+            if (submitting || !choreId) return;
+            showMessage('Opening camera...', 'info');
+            if (window.Android && typeof window.Android.openCamera === 'function') {
+                try {
+                    window.Android.openCamera('onCameraSuccess', 'onCameraError');
+                } catch (e) {
+                    showMessage('Error opening camera: ' + e.message, 'error');
+                }
+                return;
+            }
+            const cameraInput = document.getElementById('cameraInput');
+            if (cameraInput) {
+                cameraInput.click();
+            } else {
+                showMessage('Camera not available', 'error');
+            }
+        }
+
+        document.getElementById('cameraInput').addEventListener('change', function(e) {
+            const file = e.target.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = function(event) {
+                capturedImageBase64 = event.target.result;
+                document.getElementById('imagePreview').src = capturedImageBase64;
+                document.getElementById('cameraContainer').classList.remove('hidden');
+                document.getElementById('takePictureBtn').textContent = 'Retake photo';
+                hideMessage();
+            };
+            reader.readAsDataURL(file);
+        });
+
+        function retakePhoto() {
+            if (submitting) return;
+            document.getElementById('cameraContainer').classList.add('hidden');
+            document.getElementById('cameraInput').value = '';
+            capturedImageBase64 = null;
+            document.getElementById('takePictureBtn').textContent = 'Take Photo';
+            hideMessage();
+        }
+
+        function submitPhoto() {
+            if (submitting) return;
+            if (!capturedImageBase64) {
+                showMessage('Take a photo first.', 'error');
+                return;
+            }
+            if (!choreId) {
+                showMessage('This chore is missing choreId in the URL.', 'error');
+                return;
+            }
+            if (!window.Android || typeof window.Android.uploadImageToSupabase !== 'function') {
+                showMessage('Upload requires the Android app.', 'error');
+                return;
+            }
+
+            let profile = 'TE';
+            if (typeof window.Android.getCurrentProfile === 'function') {
+                try {
+                    profile = window.Android.getCurrentProfile() || 'TE';
+                } catch (e) {
+                    console.warn('Could not get profile:', e);
+                }
+            }
+
+            setBusy(true);
+            showMessage('Uploading photo...', 'info');
+
+            const uploadData = {
+                profile: profile,
+                task: imageTaskKey(choreId, rewardCash),
+                image: capturedImageBase64,
+                capture_date_time: new Date().toISOString()
+            };
+
+            try {
+                window.Android.uploadImageToSupabase(
+                    JSON.stringify(uploadData),
+                    'onUploadSuccess',
+                    'onUploadError'
+                );
+            } catch (e) {
+                setBusy(false);
+                showMessage('Error calling upload: ' + e.message, 'error');
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            readParams();
+            applyUi();
+        });
+    </script>
+</body>
+</html>

--- a/app/src/main/java/com/talq2me/baerened/BattleHubActivity.kt
+++ b/app/src/main/java/com/talq2me/baerened/BattleHubActivity.kt
@@ -820,7 +820,10 @@ class BattleHubActivity : AppCompatActivity() {
         }
 
         choresButton.setOnClickListener {
-            startActivityForResult(Intent(this, ChoresActivity::class.java), 2010)
+            val intent = Intent(this, TrainingMapActivity::class.java).apply {
+                putExtra("mapType", "chores")
+            }
+            startActivityForResult(intent, 2010)
         }
     }
     

--- a/app/src/main/java/com/talq2me/baerened/ChorePhotoActivity.kt
+++ b/app/src/main/java/com/talq2me/baerened/ChorePhotoActivity.kt
@@ -1,0 +1,284 @@
+package com.talq2me.baerened
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import android.provider.MediaStore
+import android.util.Base64
+import android.util.Log
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
+import androidx.lifecycle.lifecycleScope
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Kid-facing photo chore: show today's chore, take a picture, upload to image_uploads,
+ * then mark the photo chore complete (no berries/minutes/cash).
+ */
+class ChorePhotoActivity : AppCompatActivity() {
+
+    private lateinit var titleView: TextView
+    private lateinit var descriptionView: TextView
+    private lateinit var rewardView: TextView
+    private lateinit var preview: ImageView
+    private lateinit var cameraButton: Button
+    private lateinit var submitButton: Button
+
+    private var choreId: String = ""
+    private var choreTitle: String = ""
+    private var capturedBitmap: Bitmap? = null
+    private var cameraImageFile: File? = null
+    private var submitting = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_chore_photo)
+
+        choreId = intent.getStringExtra(EXTRA_CHORE_ID).orEmpty()
+        choreTitle = intent.getStringExtra(EXTRA_TITLE).orEmpty()
+        val description = intent.getStringExtra(EXTRA_DESCRIPTION).orEmpty()
+        val rewardCash = intent.getDoubleExtra(EXTRA_REWARD_CASH, 0.0)
+
+        titleView = findViewById(R.id.chorePhotoTitle)
+        descriptionView = findViewById(R.id.chorePhotoDescription)
+        rewardView = findViewById(R.id.chorePhotoReward)
+        preview = findViewById(R.id.chorePhotoPreview)
+        cameraButton = findViewById(R.id.chorePhotoCameraButton)
+        submitButton = findViewById(R.id.chorePhotoSubmitButton)
+
+        titleView.text = choreTitle.ifBlank { "Chore" }
+        descriptionView.text = description.ifBlank { "Take a photo of the finished chore." }
+        rewardView.text = "Reward: ${formatRewardCash(rewardCash)} (parent reviews)"
+
+        cameraButton.setOnClickListener { requestCameraAndLaunch() }
+        submitButton.setOnClickListener { submitPhoto() }
+        findViewById<Button>(R.id.chorePhotoBackButton).setOnClickListener { finish() }
+
+        if (choreId.isBlank()) {
+            Toast.makeText(this, "This chore is missing an id.", Toast.LENGTH_LONG).show()
+            finish()
+        }
+    }
+
+    private fun requestCameraAndLaunch() {
+        val granted = ContextCompat.checkSelfPermission(this, android.Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            launchCamera()
+        } else {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(android.Manifest.permission.CAMERA),
+                CAMERA_PERMISSION_REQUEST_CODE
+            )
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == CAMERA_PERMISSION_REQUEST_CODE) {
+            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                launchCamera()
+            } else {
+                Toast.makeText(this, "Camera permission is required to take a chore photo.", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
+    private fun launchCamera() {
+        try {
+            val imageFile = File(
+                getExternalFilesDir(android.os.Environment.DIRECTORY_PICTURES),
+                "chore_photo_${System.currentTimeMillis()}.jpg"
+            )
+            imageFile.parentFile?.mkdirs()
+            cameraImageFile = imageFile
+            val imageUri = FileProvider.getUriForFile(this, "${packageName}.fileprovider", imageFile)
+            val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
+                putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
+                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            val resInfoList = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+            for (resolveInfo in resInfoList) {
+                grantUriPermission(
+                    resolveInfo.activityInfo.packageName,
+                    imageUri,
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            }
+            startActivityForResult(intent, CAMERA_REQUEST_CODE)
+        } catch (e: Exception) {
+            Log.e(TAG, "launchCamera failed", e)
+            Toast.makeText(this, "Could not open camera.", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != CAMERA_REQUEST_CODE) return
+        val imageFile = cameraImageFile
+        if (resultCode != RESULT_OK) {
+            imageFile?.delete()
+            cameraImageFile = null
+            return
+        }
+        var bitmap: Bitmap? = null
+        if (imageFile != null && imageFile.exists() && imageFile.length() > 0) {
+            bitmap = decodeDownsampled(imageFile.absolutePath)
+        }
+        if (bitmap == null) {
+            bitmap = data?.extras?.get("data") as? Bitmap
+        }
+        imageFile?.delete()
+        cameraImageFile = null
+        if (bitmap == null) {
+            Toast.makeText(this, "Could not read the photo. Please try again.", Toast.LENGTH_LONG).show()
+            return
+        }
+        capturedBitmap = bitmap
+        preview.setImageBitmap(bitmap)
+        preview.visibility = View.VISIBLE
+        cameraButton.text = "Retake photo"
+        submitButton.visibility = View.VISIBLE
+        submitButton.isEnabled = true
+    }
+
+    private fun submitPhoto() {
+        if (submitting) return
+        val bitmap = capturedBitmap
+        if (bitmap == null) {
+            Toast.makeText(this, "Take a photo first.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val profile = SettingsManager.readProfile(this) ?: "AM"
+        submitting = true
+        submitButton.isEnabled = false
+        cameraButton.isEnabled = false
+        Toast.makeText(this, "Uploading photo...", Toast.LENGTH_SHORT).show()
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val supabase = SupabaseInterface()
+            if (!supabase.isConfigured()) {
+                withContext(Dispatchers.Main) {
+                    submitting = false
+                    submitButton.isEnabled = true
+                    cameraButton.isEnabled = true
+                    Toast.makeText(this@ChorePhotoActivity, "Supabase is not configured.", Toast.LENGTH_LONG).show()
+                }
+                return@launch
+            }
+            val taskKey = imageTaskKey(choreId)
+            val upload = supabase.invokeAfUpsertImageUpload(profile, taskKey, bitmapToBase64(bitmap))
+            if (upload.isFailure) {
+                withContext(Dispatchers.Main) {
+                    submitting = false
+                    submitButton.isEnabled = true
+                    cameraButton.isEnabled = true
+                    Toast.makeText(
+                        this@ChorePhotoActivity,
+                        "Could not save photo: ${upload.exceptionOrNull()?.message ?: "unknown error"}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+                return@launch
+            }
+            val complete = supabase.invokeAfUpdatePhotoChore(profile, choreId)
+            if (complete.isFailure) {
+                withContext(Dispatchers.Main) {
+                    submitting = false
+                    submitButton.isEnabled = true
+                    cameraButton.isEnabled = true
+                    Toast.makeText(
+                        this@ChorePhotoActivity,
+                        "Photo saved but could not mark the chore done: ${complete.exceptionOrNull()?.message ?: "unknown error"}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+                return@launch
+            }
+            withContext(Dispatchers.Main) {
+                val result = Intent().apply {
+                    putExtra(EXTRA_CHORE_ID, choreId)
+                    putExtra(EXTRA_TITLE, choreTitle)
+                    putExtra(EXTRA_ALREADY_COMPLETED, true)
+                }
+                setResult(RESULT_OK, result)
+                finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "ChorePhotoActivity"
+        const val EXTRA_CHORE_ID = "choreId"
+        const val EXTRA_TITLE = "choreTitle"
+        const val EXTRA_DESCRIPTION = "choreDescription"
+        const val EXTRA_REWARD_CASH = "rewardCash"
+        const val EXTRA_ALREADY_COMPLETED = "alreadyCompleted"
+        const val REQUEST_CHORE_PHOTO = 1009
+        private const val CAMERA_PERMISSION_REQUEST_CODE = 2101
+        private const val CAMERA_REQUEST_CODE = 2102
+        private const val MAX_IMAGE_EDGE = 1600
+
+        fun formatRewardCash(amount: Double?): String {
+            val value = amount ?: 0.0
+            return if (kotlin.math.abs(value - value.toLong().toDouble()) < 0.001) {
+                "$${value.toLong()}"
+            } else {
+                String.format(Locale.US, "$%.2f", value)
+            }
+        }
+
+        fun imageTaskKey(choreId: String): String {
+            val fmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+            fmt.timeZone = TimeZone.getTimeZone("America/Toronto")
+            return "chore_${choreId}_${fmt.format(Date())}"
+        }
+
+        private fun decodeDownsampled(path: String): Bitmap? {
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(path, bounds)
+            var sample = 1
+            val largest = maxOf(bounds.outWidth, bounds.outHeight)
+            while (largest / sample > MAX_IMAGE_EDGE * 2 && sample < 32) {
+                sample *= 2
+            }
+            val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+            val decoded = BitmapFactory.decodeFile(path, opts) ?: return null
+            val w = decoded.width
+            val h = decoded.height
+            val edge = maxOf(w, h)
+            if (edge <= MAX_IMAGE_EDGE) return decoded
+            val scale = MAX_IMAGE_EDGE.toFloat() / edge
+            return Bitmap.createScaledBitmap(decoded, (w * scale).toInt().coerceAtLeast(1), (h * scale).toInt().coerceAtLeast(1), true)
+        }
+
+        private fun bitmapToBase64(bitmap: Bitmap): String {
+            val outputStream = ByteArrayOutputStream()
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 85, outputStream)
+            return Base64.encodeToString(outputStream.toByteArray(), Base64.NO_WRAP)
+        }
+    }
+}

--- a/app/src/main/java/com/talq2me/baerened/DbProfileSessionLoader.kt
+++ b/app/src/main/java/com/talq2me/baerened/DbProfileSessionLoader.kt
@@ -62,13 +62,14 @@ class DbProfileSessionLoader(private val context: Context) {
         if (!syncService.isConfigured()) {
             return@withContext Result.failure(Exception("Supabase not configured"))
         }
-        Log.d(TAG, "runGithubTaskConfigRpcsThenRefetch(profile=$profile): af_update_*_from_config ×5, then fetchUserData")
+        Log.d(TAG, "runGithubTaskConfigRpcsThenRefetch(profile=$profile): af_update_*_from_config ×6, then fetchUserData")
         val steps = listOf(
             "required_tasks" to syncService::invokeAfUpdateRequiredTasksFromConfig,
             "practice_tasks" to syncService::invokeAfUpdatePracticeTasksFromConfig,
             "bonus_tasks" to syncService::invokeAfUpdateBonusTasksFromConfig,
             "checklist_items" to syncService::invokeAfUpdateChecklistItemsFromConfig,
-            "chores" to syncService::invokeAfUpdateChoresFromGitHub
+            "chores" to syncService::invokeAfUpdateChoresFromGitHub,
+            "photo_chores" to syncService::invokeAfUpdatePhotoChoresFromConfig
         )
         for ((name, invoke) in steps) {
             val result = invoke(profile)

--- a/app/src/main/java/com/talq2me/baerened/DbUserData.kt
+++ b/app/src/main/java/com/talq2me/baerened/DbUserData.kt
@@ -41,6 +41,9 @@ data class DbUserData(
     // Chores 4 $$: array of chore state (chore_id, description, coins_reward, done); done resets daily
     @SerializedName("chores") val chores: List<ChoreProgress> = emptyList(),
 
+    // Photo chores (trainer map): object keyed by chore id
+    @SerializedName("photo_chores") val photoChores: Map<String, PhotoChoreProgress> = emptyMap(),
+
     // Pokemon data
     @SerializedName("pokemon_unlocked") val pokemonUnlocked: Int = 0,
 
@@ -109,4 +112,20 @@ data class ChoreProgress(
     @SerializedName("description") val description: String = "",
     @SerializedName("coins_reward") val coinsReward: Int = 0,
     @SerializedName("done") val done: Boolean = false
+)
+
+/**
+ * Photo-chore progress stored in user_data.photo_chores (object keyed by chore id).
+ * status resets daily; photos stay in image_uploads.
+ */
+data class PhotoChoreProgress(
+    @SerializedName("status") val status: String = "incomplete",
+    @SerializedName("title") val title: String? = null,
+    @SerializedName("description") val description: String? = null,
+    @SerializedName("rewardCash") val rewardCash: Double? = null,
+    @SerializedName("launch") val launch: String? = null,
+    @SerializedName("displayDays") val displayDays: String? = null,
+    @SerializedName("showdays") val showdays: String? = null,
+    @SerializedName("hidedays") val hidedays: String? = null,
+    @SerializedName("disable") val disable: String? = null
 )

--- a/app/src/main/java/com/talq2me/baerened/Layout.kt
+++ b/app/src/main/java/com/talq2me/baerened/Layout.kt
@@ -1088,7 +1088,7 @@ open class Layout(protected val activity: MainActivity) {
             val section = sections[index]
             android.util.Log.d("Layout", "Creating section ${index + 1}/${sections.size}: ${section.title}, tasks count: ${section.tasks?.size ?: 0}")
             when (section.id) {
-                "required", "optional", "bonus", "checklist" -> {
+                "required", "optional", "bonus", "checklist", "chores" -> {
                     renderSectionFromDb(section, section.id ?: "") {
                         createSectionsIncrementally(sections, index + 1)
                     }
@@ -1106,7 +1106,7 @@ open class Layout(protected val activity: MainActivity) {
     /**
      * Dashboard section render, DB-driven for known section ids.
      *
-     * - "required" / "optional" / "bonus" — list + completion from `af_get_tasks_*`.
+     * - "required" / "optional" / "bonus" / "chores" — list + completion from `af_get_tasks_*`.
      * - "checklist" — visibility/completion from `af_get_tasks_required` (`is_checklist` rows).
      *
      * No `DailyProgressManager` for these sections: Postgres already filters by today.
@@ -1647,6 +1647,17 @@ open class Layout(protected val activity: MainActivity) {
     private fun launchTask(task: Task, sectionId: String, sourceTaskId: String? = null) {
         val gameType = task.launch ?: "unknown"
         val gameTitle = task.title ?: "Task"
+
+        if (task.launch == "chorePhoto" || sectionId == "chores") {
+            val intent = android.content.Intent(activity, ChorePhotoActivity::class.java).apply {
+                putExtra(ChorePhotoActivity.EXTRA_CHORE_ID, task.choreId ?: "")
+                putExtra(ChorePhotoActivity.EXTRA_TITLE, gameTitle)
+                putExtra(ChorePhotoActivity.EXTRA_DESCRIPTION, task.description ?: "")
+                putExtra(ChorePhotoActivity.EXTRA_REWARD_CASH, task.rewardCash ?: 0.0)
+            }
+            activity.startActivityForResult(intent, ChorePhotoActivity.REQUEST_CHORE_PHOTO)
+            return
+        }
         
         // Check if this is a Chrome page task
         if (task.chromePage == true) {
@@ -2393,6 +2404,7 @@ open class Layout(protected val activity: MainActivity) {
             text = when (mapType) {
                 "optional" -> "🗺️ Extra Practice Map 🗺️"
                 "bonus" -> "🎮 Bonus Training Map 🎮"
+                "chores" -> "🧹 Chores Map 🧹"
                 else -> "🗺️ Training Map 🗺️"
             }
             textSize = 24f

--- a/app/src/main/java/com/talq2me/baerened/MainActivity.kt
+++ b/app/src/main/java/com/talq2me/baerened/MainActivity.kt
@@ -1616,7 +1616,13 @@ data class Task(
     val displayDays: String? = null,
     val disable: String? = null,
     /** When true, tappableText uses simpler English hints for tap questions (see [TappableTextActivity]). */
-    val easy: Boolean? = null
+    val easy: Boolean? = null,
+    /** Photo-chore id (config `id`); used as photo_chores JSON key. */
+    val choreId: String? = null,
+    /** Photo-chore instructions shown on the camera screen. */
+    val description: String? = null,
+    /** Parent-review cash amount for photo chores (dollars). */
+    val rewardCash: Double? = null
 )
 
 data class ChecklistItem(

--- a/app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt
+++ b/app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt
@@ -269,6 +269,9 @@ open class SupabaseInterface {
     suspend fun invokeAfUpdateChecklistItemsFromConfig(profile: String): Result<Unit> =
         invokeRpcProfileWithConfigJson("af_update_tasks_from_config_checklist_items", profile)
 
+    suspend fun invokeAfUpdatePhotoChoresFromConfig(profile: String): Result<Unit> =
+        invokeRpcProfileWithConfigJson("af_update_tasks_from_config_photo_chores", profile)
+
     suspend fun invokeAfUpdateChoresFromGitHub(profile: String): Result<Unit> {
         val choresJson = fetchChoresJsonFromGitHubPages().getOrElse { err ->
             return Result.failure(Exception("Could not fetch GitHub Pages chores.json: ${err.message}"))
@@ -320,6 +323,10 @@ open class SupabaseInterface {
     /** Stable bonus rows (current impl routed in SQL). */
     suspend fun invokeAfGetBonusTasksRows(profile: String): Result<JsonArray> =
         invokeRpcProfileReturningJsonArray("af_get_tasks_bonus", profile)
+
+    /** Today's photo-chore gym rows (current impl routed in SQL). */
+    suspend fun invokeAfGetPhotoChoreTasksRows(profile: String): Result<JsonArray> =
+        invokeRpcProfileReturningJsonArray("af_get_tasks_photo_chores", profile)
 
     /**
      * Today's required-task progress. `allDone` is true iff every visible-today required task AND every visible-today
@@ -503,6 +510,12 @@ open class SupabaseInterface {
     suspend fun invokeAfUpdateChecklistItem(profile: String, itemLabel: String, done: Boolean): Result<Unit> {
         val body = """{"p_profile":"${profile.escapeJson()}", "p_item_label":"${itemLabel.escapeJson()}", "p_done":$done}"""
         return invokeRpc("af_update_tasks_checklist_items", body)
+    }
+
+    /** Calls af_update_tasks_photo_chores; marks a photo chore complete (no cash/berries). */
+    suspend fun invokeAfUpdatePhotoChore(profile: String, choreId: String): Result<Unit> {
+        val body = """{"p_profile":"${profile.escapeJson()}", "p_chore_id":"${choreId.escapeJson()}"}"""
+        return invokeRpc("af_update_tasks_photo_chores", body)
     }
 
     /** Calls af_update_tasks_chores; DB updates chore and coins_earned. */
@@ -748,7 +761,7 @@ open class SupabaseInterface {
      */
     private fun fixJsonbFieldsInObject(obj: JsonObject) {
         // JSONB fields that should be objects (not strings)
-        val jsonbObjectFields = listOf("required_tasks", "practice_tasks", "bonus_tasks", "checklist_items", "game_indices")
+        val jsonbObjectFields = listOf("required_tasks", "practice_tasks", "bonus_tasks", "checklist_items", "game_indices", "photo_chores")
         jsonbObjectFields.forEach { fieldName ->
             val field = obj.get(fieldName)
             if (field != null) {

--- a/app/src/main/java/com/talq2me/baerened/TaskLauncher.kt
+++ b/app/src/main/java/com/talq2me/baerened/TaskLauncher.kt
@@ -92,6 +92,9 @@ class TaskLauncher(
             task.launch == "spellingOCR" -> {
                 launchSpellingOCRGame(task, sectionId, sourceTaskId, resultHandler)
             }
+            task.launch == "chorePhoto" || sectionId == "chores" -> {
+                launchChorePhotoTask(task, resultHandler)
+            }
             // Regular game tasks
             else -> {
                 launchGameTask(task, sectionId, sourceTaskId, resultHandler)
@@ -119,6 +122,17 @@ class TaskLauncher(
         }
 
         resultHandler?.launchActivity(intent, 1001) ?: (context as? Activity)?.startActivityForResult(intent, 1001)
+    }
+
+    private fun launchChorePhotoTask(task: Task, resultHandler: ActivityResultHandler?) {
+        val intent = Intent(context, ChorePhotoActivity::class.java).apply {
+            putExtra(ChorePhotoActivity.EXTRA_CHORE_ID, task.choreId ?: "")
+            putExtra(ChorePhotoActivity.EXTRA_TITLE, task.title ?: "Chore")
+            putExtra(ChorePhotoActivity.EXTRA_DESCRIPTION, task.description ?: "")
+            putExtra(ChorePhotoActivity.EXTRA_REWARD_CASH, task.rewardCash ?: 0.0)
+        }
+        resultHandler?.launchActivity(intent, ChorePhotoActivity.REQUEST_CHORE_PHOTO)
+            ?: (context as? Activity)?.startActivityForResult(intent, ChorePhotoActivity.REQUEST_CHORE_PHOTO)
     }
 
     /**

--- a/app/src/main/java/com/talq2me/baerened/TrainerMapTaskMerge.kt
+++ b/app/src/main/java/com/talq2me/baerened/TrainerMapTaskMerge.kt
@@ -35,7 +35,10 @@ object TrainerMapTaskMerge {
         val extremedays: String?,
         val easy: Boolean,
         val blockOutlines: Boolean,
-        val isChecklist: Boolean
+        val isChecklist: Boolean,
+        val choreId: String? = null,
+        val description: String? = null,
+        val rewardCash: Double? = null
     )
 
     fun parseRows(arr: JsonArray): List<DbRow> {
@@ -66,7 +69,10 @@ object TrainerMapTaskMerge {
                     extremedays = o.stringOrNull("extremedays"),
                     easy = o.boolOrDefault("easy", false),
                     blockOutlines = o.boolOrDefault("block_outlines", false),
-                    isChecklist = o.boolOrDefault("is_checklist", false)
+                    isChecklist = o.boolOrDefault("is_checklist", false),
+                    choreId = o.stringOrNull("chore_id"),
+                    description = o.stringOrNull("description"),
+                    rewardCash = o.doubleOrNull("reward_cash")
                 )
             )
         }
@@ -92,7 +98,10 @@ object TrainerMapTaskMerge {
             easydays = row.easydays,
             harddays = row.harddays,
             extremedays = row.extremedays,
-            easy = row.easy
+            easy = row.easy,
+            choreId = row.choreId,
+            description = row.description,
+            rewardCash = row.rewardCash
         )
     }
 
@@ -125,6 +134,7 @@ object TrainerMapTaskMerge {
         taskForLaunch(supabase.invokeAfGetRequiredTasksRows(profile).getOrNull())?.let { return it to "required" }
         taskForLaunch(supabase.invokeAfGetPracticeTasksRows(profile).getOrNull())?.let { return it to "optional" }
         taskForLaunch(supabase.invokeAfGetBonusTasksRows(profile).getOrNull())?.let { return it to "bonus" }
+        taskForLaunch(supabase.invokeAfGetPhotoChoreTasksRows(profile).getOrNull())?.let { return it to "chores" }
         return null
     }
 
@@ -155,6 +165,16 @@ object TrainerMapTaskMerge {
                 "0", "false", "f", "no", "n" -> false
                 else -> default
             }
+        }
+    }
+
+    private fun JsonObject.doubleOrNull(key: String): Double? {
+        val v = get(key) ?: return null
+        if (v.isJsonNull) return null
+        return try {
+            v.asDouble
+        } catch (_: Exception) {
+            v.asString.toDoubleOrNull()
         }
     }
 
@@ -191,6 +211,7 @@ object TrainerMapTaskMerge {
             "required", "checklist" -> supabase.invokeAfGetRequiredTasksRows(profile)
             "optional" -> supabase.invokeAfGetPracticeTasksRows(profile)
             "bonus" -> supabase.invokeAfGetBonusTasksRows(profile)
+            "chores" -> supabase.invokeAfGetPhotoChoreTasksRows(profile)
             else -> Result.failure(IllegalArgumentException("Unknown mapType: $mapType"))
         }
         if (rowsResult.isFailure) {

--- a/app/src/main/java/com/talq2me/baerened/TrainingMapActivity.kt
+++ b/app/src/main/java/com/talq2me/baerened/TrainingMapActivity.kt
@@ -214,6 +214,7 @@ open class TrainingMapActivity : AppCompatActivity() {
                 "optional" -> "🗺️ Extra Practice Map 🗺️"
                 "bonus" -> "🎮 Bonus Training Map 🎮"
                 "checklist" -> "✅ Checklist Map ✅"
+                "chores" -> "🧹 Chores Map 🧹"
                 else -> "🗺️ Training Map 🗺️"
             }
             textSize = 24f
@@ -572,8 +573,12 @@ open class TrainingMapActivity : AppCompatActivity() {
                         
                         // Text overlay (title and stars icon) - smaller text
                         val textOverlay = TextView(this@TrainingMapActivity).apply {
-                            val starsCount = task.stars ?: 1
-                            text = "${task.title}\n$starsCount ${icons.starsIcon}"
+                            text = if (mapType == "chores") {
+                                "${task.title}\n${ChorePhotoActivity.formatRewardCash(task.rewardCash)}"
+                            } else {
+                                val starsCount = task.stars ?: 1
+                                "${task.title}\n$starsCount ${icons.starsIcon}"
+                            }
                             textSize = 8f // Smaller text to prevent wrapping
                             setTextColor(if (isCompleted) android.graphics.Color.GRAY else android.graphics.Color.BLACK)
                             setTypeface(null, android.graphics.Typeface.BOLD)
@@ -674,6 +679,18 @@ open class TrainingMapActivity : AppCompatActivity() {
         // Videos should be handled before trying to fetch game content from data/ folder
         if (task.videoSequence != null) {
             handleVideoSequenceTask(task, sectionId)
+            return
+        }
+
+        if (task.launch == "chorePhoto" || mapType == "chores") {
+            lastLaunchedGameSectionId = sectionId
+            val intent = Intent(this, ChorePhotoActivity::class.java).apply {
+                putExtra(ChorePhotoActivity.EXTRA_CHORE_ID, task.choreId ?: task.launch)
+                putExtra(ChorePhotoActivity.EXTRA_TITLE, gameTitle)
+                putExtra(ChorePhotoActivity.EXTRA_DESCRIPTION, task.description ?: "")
+                putExtra(ChorePhotoActivity.EXTRA_REWARD_CASH, task.rewardCash ?: 0.0)
+            }
+            startActivityForResult(intent, ChorePhotoActivity.REQUEST_CHORE_PHOTO)
             return
         }
         
@@ -1162,7 +1179,7 @@ open class TrainingMapActivity : AppCompatActivity() {
         
         // Refresh the map when returning from any task to show updated completion status
         // Only refresh if the task was completed (RESULT_OK) to avoid unnecessary refreshes
-        if ((requestCode == 1001 || requestCode == 1002 || requestCode == 1003 || requestCode == 1004 || requestCode == 1005 || requestCode == 1006 || requestCode == 1007) && resultCode == RESULT_OK) {
+        if ((requestCode == 1001 || requestCode == 1002 || requestCode == 1003 || requestCode == 1004 || requestCode == 1005 || requestCode == 1006 || requestCode == 1007 || requestCode == ChorePhotoActivity.REQUEST_CHORE_PHOTO) && resultCode == RESULT_OK) {
             val currentProfile = SettingsManager.readProfile(this) ?: "AM"
             // Task writes already went via RPC; refetch DB and apply before redraw.
             lifecycleScope.launch(Dispatchers.IO) {

--- a/app/src/main/res/layout/activity_chore_photo.xml
+++ b/app/src/main/res/layout/activity_chore_photo.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/chorePhotoTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingBottom="8dp"
+        android:textSize="22sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/chorePhotoReward"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingBottom="12dp"
+        android:textColor="#2e7d32"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/chorePhotoDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingBottom="16dp"
+        android:textSize="16sp" />
+
+    <ImageView
+        android:id="@+id/chorePhotoPreview"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
+        android:background="#e2e8f0"
+        android:contentDescription="Chore photo preview"
+        android:scaleType="centerCrop"
+        android:visibility="gone" />
+
+    <Button
+        android:id="@+id/chorePhotoCameraButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/button_rounded"
+        android:text="Take photo"
+        android:textAllCaps="false"
+        android:textColor="#FFFFFF"
+        android:textSize="18sp" />
+
+    <Button
+        android:id="@+id/chorePhotoSubmitButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/button_rounded_success"
+        android:enabled="false"
+        android:text="Submit photo"
+        android:textAllCaps="false"
+        android:textColor="#FFFFFF"
+        android:textSize="18sp"
+        android:visibility="gone" />
+
+    <Button
+        android:id="@+id/chorePhotoBackButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/button_rounded_secondary"
+        android:text="Back"
+        android:textAllCaps="false"
+        android:textColor="#FFFFFF" />
+</LinearLayout>

--- a/reports/daily_progress_report.html
+++ b/reports/daily_progress_report.html
@@ -473,9 +473,17 @@
         }
 
         function parseChoreTaskKey(task) {
+            const withReward = String(task || '').match(/^chore_(.+)_r([0-9]+(?:\.[0-9]+)?)_(\d{4}-\d{2}-\d{2})$/);
+            if (withReward) {
+                return {
+                    choreId: withReward[1],
+                    rewardCash: Number(withReward[2]),
+                    date: withReward[3]
+                };
+            }
             const m = String(task || '').match(/^chore_(.+)_(\d{4}-\d{2}-\d{2})$/);
             if (!m) return null;
-            return { choreId: m[1], date: m[2] };
+            return { choreId: m[1], rewardCash: null, date: m[2] };
         }
 
         function imageSrc(image) {
@@ -620,18 +628,18 @@
             }
             todayChorePhotos.forEach((row, idx) => {
                 const parsed = parseChoreTaskKey(row.task) || {};
-                const meta = photoChoresToday[parsed.choreId] || (reportUserData && reportUserData.photo_chores && reportUserData.photo_chores[parsed.choreId]) || {};
-                const title = meta.title || parsed.choreId || 'Chore';
-                const src = imageSrc(row.image);
-                const paid = row.reward_granted === true;
-                const card = document.createElement('div');
-                card.className = 'chore-photo-card';
-                card.innerHTML = `
-                    <img src="${src}" alt="${title}">
-                    <div class="cap">${title}${paid ? ` <span class="paid">Paid ${formatMoney(row.granted_amount)}</span>` : ''}</div>
-                `;
-                card.addEventListener('click', () => openChorePhoto(idx, photoChoresToday));
-                wrap.appendChild(card);
+            const meta = photoChoresToday[parsed.choreId] || (reportUserData && reportUserData.photo_chores && reportUserData.photo_chores[parsed.choreId]) || {};
+            const title = meta.title || String(parsed.choreId || 'Chore').replace(/_/g, ' ');
+            const src = imageSrc(row.image);
+            const paid = row.reward_granted === true;
+            const card = document.createElement('div');
+            card.className = 'chore-photo-card';
+            card.innerHTML = `
+                <img src="${src}" alt="${title}">
+                <div class="cap">${title}${paid ? ` <span class="paid">Paid ${formatMoney(row.granted_amount)}</span>` : ''}</div>
+            `;
+            card.addEventListener('click', () => openChorePhoto(idx, photoChoresToday));
+            wrap.appendChild(card);
             });
         }
 
@@ -655,8 +663,10 @@
                 idx,
                 row,
                 choreId: parsed.choreId,
-                title: meta.title || parsed.choreId || 'Chore',
-                rewardCash: meta.rewardCash != null ? Number(meta.rewardCash) : 0
+                title: meta.title || String(parsed.choreId || 'Chore').replace(/_/g, ' '),
+                rewardCash: meta.rewardCash != null
+                    ? Number(meta.rewardCash)
+                    : (parsed.rewardCash != null ? Number(parsed.rewardCash) : 0)
             };
             const modal = document.getElementById('imageModal');
             const img = document.getElementById('modalImage');

--- a/reports/daily_progress_report.html
+++ b/reports/daily_progress_report.html
@@ -222,6 +222,115 @@
             font-size: 0.9em;
         }
 
+        .chore-photos {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+            gap: 8px;
+            margin: 8px 0 12px;
+        }
+
+        .chore-photo-card {
+            background: #f8fafc;
+            border-radius: 8px;
+            overflow: hidden;
+            cursor: pointer;
+            border: 1px solid #e2e8f0;
+        }
+
+        .chore-photo-card img {
+            width: 100%;
+            height: 96px;
+            object-fit: cover;
+            display: block;
+        }
+
+        .chore-photo-card .cap {
+            font-size: 0.68em;
+            padding: 4px 6px;
+            color: #334155;
+            line-height: 1.2;
+        }
+
+        .chore-photo-card .cap .paid {
+            color: #15803d;
+            font-weight: 700;
+        }
+
+        .modal {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.82);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+            padding: 16px;
+        }
+
+        .modal.show { display: flex; }
+
+        .modal-content {
+            max-width: 96vw;
+            max-height: 82vh;
+            object-fit: contain;
+            border-radius: 8px;
+        }
+
+        .modal-close {
+            position: absolute;
+            top: 12px;
+            right: 16px;
+            color: white;
+            font-size: 32px;
+            cursor: pointer;
+            line-height: 1;
+        }
+
+        .grant-dialog {
+            background: white;
+            border-radius: 12px;
+            padding: 16px;
+            width: min(420px, 100%);
+            box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+        }
+
+        .grant-dialog h4 {
+            margin-bottom: 8px;
+            color: #334155;
+        }
+
+        .grant-dialog p {
+            font-size: 0.9em;
+            color: #475569;
+            margin-bottom: 10px;
+        }
+
+        .grant-dialog input {
+            width: 100%;
+            padding: 8px 10px;
+            border: 1px solid #cbd5e1;
+            border-radius: 8px;
+            font-size: 1em;
+            margin-bottom: 12px;
+        }
+
+        .grant-actions {
+            display: flex;
+            gap: 8px;
+            justify-content: flex-end;
+        }
+
+        .grant-actions button {
+            border: none;
+            border-radius: 8px;
+            padding: 8px 14px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .grant-no { background: #e2e8f0; color: #334155; }
+        .grant-yes { background: #15803d; color: white; }
+
         @media (min-width: 480px) {
             body { padding: 16px; }
             .header { padding: 12px 14px; }
@@ -313,7 +422,25 @@
 
             <div class="section" id="choresSection">
                 <h3>Chores</h3>
+                <div id="chorePhotos" class="chore-photos"></div>
                 <ul class="task-list" id="choresList"></ul>
+            </div>
+        </div>
+    </div>
+
+    <div id="imageModal" class="modal" aria-hidden="true">
+        <span class="modal-close" id="imageModalClose">&times;</span>
+        <img class="modal-content" id="modalImage" alt="Chore photo">
+    </div>
+
+    <div id="grantModal" class="modal" aria-hidden="true">
+        <div class="grant-dialog">
+            <h4 id="grantTitle">Grant chore reward?</h4>
+            <p id="grantMessage">Add this amount to the kid's bank.</p>
+            <input id="grantAmount" type="number" min="0" step="0.01" inputmode="decimal">
+            <div class="grant-actions">
+                <button type="button" class="grant-no" id="grantNo">No</button>
+                <button type="button" class="grant-yes" id="grantYes">Yes</button>
             </div>
         </div>
     </div>
@@ -326,16 +453,65 @@
         // Load Supabase configuration
         const supabaseUrl = localStorage.getItem('supabaseUrl');
         const supabaseKey = localStorage.getItem('supabaseKey');
+        const restHeaders = {
+            'apikey': supabaseKey,
+            'Authorization': `Bearer ${supabaseKey}`,
+            'Content-Type': 'application/json'
+        };
 
-        // Fetch data from Supabase
+        let reportUserData = null;
+        let todayChorePhotos = [];
+        let openPhoto = null;
+
+        function todayTorontoYmd() {
+            return new Intl.DateTimeFormat('en-CA', {
+                timeZone: 'America/Toronto',
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit'
+            }).format(new Date());
+        }
+
+        function parseChoreTaskKey(task) {
+            const m = String(task || '').match(/^chore_(.+)_(\d{4}-\d{2}-\d{2})$/);
+            if (!m) return null;
+            return { choreId: m[1], date: m[2] };
+        }
+
+        function imageSrc(image) {
+            if (!image) return '';
+            return image.startsWith('data:image') ? image : ('data:image/jpeg;base64,' + image);
+        }
+
+        function formatMoney(amount) {
+            const n = Number(amount);
+            if (!isFinite(n)) return '$0.00';
+            return n.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+        }
+
+        async function fetchTodayChorePhotos() {
+            const today = todayTorontoYmd();
+            const url = `${supabaseUrl}/rest/v1/image_uploads?profile=eq.${encodeURIComponent(kid)}&task=like.chore_*&select=task,image,capture_date_time,reward_granted,granted_amount&order=capture_date_time.desc`;
+            let response = await fetch(url, { headers: restHeaders });
+            if (!response.ok) {
+                const fallbackUrl = `${supabaseUrl}/rest/v1/image_uploads?profile=eq.${encodeURIComponent(kid)}&task=like.chore_*&select=task,image,capture_date_time&order=capture_date_time.desc`;
+                response = await fetch(fallbackUrl, { headers: restHeaders });
+            }
+            if (!response.ok) {
+                throw new Error(`image_uploads: ${response.status}`);
+            }
+            const rows = await response.json();
+            return (Array.isArray(rows) ? rows : []).filter(row => {
+                const parsed = parseChoreTaskKey(row.task);
+                const captureDay = String(row.capture_date_time || '').slice(0, 10);
+                return parsed && (parsed.date === today || captureDay === today);
+            });
+        }
+
         async function fetchReportData() {
             try {
                 const response = await fetch(`${supabaseUrl}/rest/v1/user_data?profile=eq.${kid}&select=*`, {
-                    headers: {
-                        'apikey': supabaseKey,
-                        'Authorization': `Bearer ${supabaseKey}`,
-                        'Content-Type': 'application/json'
-                    }
+                    headers: restHeaders
                 });
 
                 if (!response.ok) {
@@ -348,8 +524,14 @@
                     throw new Error(`No data found for profile: ${kid}`);
                 }
 
-                const userData = data[0];
-                displayReport(userData);
+                reportUserData = data[0];
+                try {
+                    todayChorePhotos = await fetchTodayChorePhotos();
+                } catch (photoErr) {
+                    console.warn('Chore photos unavailable', photoErr);
+                    todayChorePhotos = [];
+                }
+                displayReport(reportUserData);
             } catch (error) {
                 console.error('Error fetching data:', error);
                 document.getElementById('loading').style.display = 'none';
@@ -428,6 +610,131 @@
 
             return true; // Visible by default if no restrictions
         }
+
+        function renderChorePhotos(photoChoresToday) {
+            const wrap = document.getElementById('chorePhotos');
+            wrap.innerHTML = '';
+            if (!todayChorePhotos.length) {
+                wrap.innerHTML = '<div class="task-info">No chore photos uploaded today.</div>';
+                return;
+            }
+            todayChorePhotos.forEach((row, idx) => {
+                const parsed = parseChoreTaskKey(row.task) || {};
+                const meta = photoChoresToday[parsed.choreId] || (reportUserData && reportUserData.photo_chores && reportUserData.photo_chores[parsed.choreId]) || {};
+                const title = meta.title || parsed.choreId || 'Chore';
+                const src = imageSrc(row.image);
+                const paid = row.reward_granted === true;
+                const card = document.createElement('div');
+                card.className = 'chore-photo-card';
+                card.innerHTML = `
+                    <img src="${src}" alt="${title}">
+                    <div class="cap">${title}${paid ? ` <span class="paid">Paid ${formatMoney(row.granted_amount)}</span>` : ''}</div>
+                `;
+                card.addEventListener('click', () => openChorePhoto(idx, photoChoresToday));
+                wrap.appendChild(card);
+            });
+        }
+
+        function closeImageModalOnly() {
+            const modal = document.getElementById('imageModal');
+            modal.classList.remove('show');
+            document.getElementById('modalImage').src = '';
+            document.body.style.overflow = '';
+        }
+
+        function closeGrantModal() {
+            document.getElementById('grantModal').classList.remove('show');
+        }
+
+        function openChorePhoto(idx, photoChoresToday) {
+            const row = todayChorePhotos[idx];
+            if (!row) return;
+            const parsed = parseChoreTaskKey(row.task) || {};
+            const meta = photoChoresToday[parsed.choreId] || {};
+            openPhoto = {
+                idx,
+                row,
+                choreId: parsed.choreId,
+                title: meta.title || parsed.choreId || 'Chore',
+                rewardCash: meta.rewardCash != null ? Number(meta.rewardCash) : 0
+            };
+            const modal = document.getElementById('imageModal');
+            const img = document.getElementById('modalImage');
+            img.src = imageSrc(row.image);
+            modal.classList.add('show');
+            document.body.style.overflow = 'hidden';
+        }
+
+        function requestCloseChorePhoto() {
+            const modal = document.getElementById('imageModal');
+            if (!modal.classList.contains('show')) return;
+            closeImageModalOnly();
+            const photo = openPhoto;
+            if (!photo) return;
+            if (photo.row.reward_granted === true) {
+                openPhoto = null;
+                return;
+            }
+            document.getElementById('grantTitle').textContent = `Grant reward for ${photo.title}?`;
+            document.getElementById('grantMessage').textContent = `Add this amount to ${kid}'s bank.`;
+            document.getElementById('grantAmount').value = Number(photo.rewardCash || 0).toFixed(2);
+            document.getElementById('grantModal').classList.add('show');
+        }
+
+        async function grantChoreReward() {
+            const photo = openPhoto;
+            if (!photo) {
+                closeGrantModal();
+                return;
+            }
+            const amount = Number(document.getElementById('grantAmount').value);
+            if (!isFinite(amount) || amount < 0) {
+                alert('Enter a valid amount (0 or more).');
+                return;
+            }
+            const yesBtn = document.getElementById('grantYes');
+            yesBtn.disabled = true;
+            try {
+                const response = await fetch(`${supabaseUrl}/rest/v1/rpc/af_grant_chore_reward`, {
+                    method: 'POST',
+                    headers: restHeaders,
+                    body: JSON.stringify({
+                        p_profile: kid,
+                        p_task_key: photo.row.task,
+                        p_amount: amount
+                    })
+                });
+                if (!response.ok) {
+                    throw new Error(await response.text() || response.statusText);
+                }
+                const result = await response.json();
+                todayChorePhotos[photo.idx].reward_granted = true;
+                todayChorePhotos[photo.idx].granted_amount = result.granted_amount != null ? result.granted_amount : amount;
+                closeGrantModal();
+                openPhoto = null;
+                if (reportUserData) displayReport(reportUserData);
+            } catch (err) {
+                alert('Could not grant reward: ' + (err.message || err));
+            } finally {
+                yesBtn.disabled = false;
+            }
+        }
+
+        document.getElementById('imageModalClose').addEventListener('click', requestCloseChorePhoto);
+        document.getElementById('imageModal').addEventListener('click', function(e) {
+            if (e.target === this) requestCloseChorePhoto();
+        });
+        document.getElementById('grantNo').addEventListener('click', function() {
+            closeGrantModal();
+            openPhoto = null;
+        });
+        document.getElementById('grantYes').addEventListener('click', grantChoreReward);
+        document.getElementById('grantModal').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closeGrantModal();
+                openPhoto = null;
+            }
+        });
 
         // Display the report
         function displayReport(userData) {
@@ -519,9 +826,18 @@
             }
 
             // Chores 4 🪙 (today = done=true; coins today = sum of coins_reward for done)
+            const allPhotoChores = userData.photo_chores || {};
+            const photoChoresToday = {};
+            for (const [choreId, chore] of Object.entries(allPhotoChores)) {
+                if (isTaskVisible(chore.showdays, chore.hidedays, chore.displayDays, chore.disable)) {
+                    photoChoresToday[choreId] = chore;
+                }
+            }
+            const photoChoresCompletedToday = Object.values(photoChoresToday).filter(c => (c.status || '').toLowerCase() === 'complete').length;
+
             const chores = userData.chores || [];
             const doneChores = Array.isArray(chores) ? chores.filter(c => c.done === true) : [];
-            const choresCompletedToday = doneChores.length;
+            const choresCompletedToday = doneChores.length + photoChoresCompletedToday;
             const coinsEarnedToday = doneChores.reduce((sum, c) => sum + (c.coins_reward || 0), 0);
             const coinsEarnedLifetime = userData.coins_earned || 0;
 
@@ -539,7 +855,23 @@
 
             const choresListEl = document.getElementById('choresList');
             choresListEl.innerHTML = '';
-            if (chores.length === 0) {
+            renderChorePhotos(photoChoresToday);
+            const photoChoreIds = Object.keys(photoChoresToday);
+            if (photoChoreIds.length > 0) {
+                photoChoreIds.forEach(choreId => {
+                    const chore = photoChoresToday[choreId];
+                    const isDone = (chore.status || '').toLowerCase() === 'complete';
+                    const desc = chore.title || chore.description || choreId;
+                    const reward = chore.rewardCash != null ? chore.rewardCash : 0;
+                    const li = document.createElement('li');
+                    li.className = `task-item ${isDone ? '' : 'incomplete'}`;
+                    li.innerHTML = `
+                        <span class="task-name">${isDone ? '✓' : '○'} ${desc}</span>
+                        <span class="task-info">${formatMoney(reward)} ${isDone ? 'Photo submitted' : 'Not done'}</span>
+                    `;
+                    choresListEl.appendChild(li);
+                });
+            } else if (chores.length === 0) {
                 choresListEl.innerHTML = '<li class="task-item"><span class="task-name">No chores configured</span></li>';
             } else {
                 chores.forEach(chore => {

--- a/sql/af_daily_reset.sql
+++ b/sql/af_daily_reset.sql
@@ -4,7 +4,7 @@
 
 -- BaerenEd: Daily reset applied at read time (AF = "at fetch").
 -- Call this before reading user_data so the row for the given profile with last_reset date not equal to today (Toronto time)
--- gets reset: blank required_tasks, checklist_items, practice_tasks, berries_earned, banked_mins, chores;
+-- gets reset: blank required_tasks, checklist_items, practice_tasks, berries_earned, banked_mins, chores, photo_chores;
 -- set last_reset and last_updated to now() in America/Toronto. Does not change coins_earned, pokemon_unlocked, game_indices.
 -- When a reset row was updated (FOUND), repopulates task/chore columns from GitHub via af_update_*
 -- (full implementations are in the per-function af_update_* files in sql/).
@@ -33,7 +33,8 @@ BEGIN
     banked_mins = 0,
     reward_time_expiry = NULL,
     prize_unlocked = NULL,
-    chores = '[]'::jsonb
+    chores = '[]'::jsonb,
+    photo_chores = '{}'::jsonb
   WHERE profile = p_profile
     AND (last_reset IS NULL OR last_reset::date IS DISTINCT FROM today_est);
 
@@ -42,6 +43,7 @@ BEGIN
     PERFORM af_update_tasks_from_config_practice(p_profile);
     PERFORM af_update_tasks_from_config_bonus(p_profile);
     PERFORM af_update_tasks_from_config_chores(p_profile);
+    PERFORM af_update_tasks_from_config_photo_chores(p_profile);
   END IF;
 END;
 $$;

--- a/sql/af_get_tasks_photo_chores.sql
+++ b/sql/af_get_tasks_photo_chores.sql
@@ -1,0 +1,111 @@
+-- Call sites (BaerenEd Android, this repo):
+--   app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt  -  invokeAfGetPhotoChoreTasksRows.
+--   app/src/main/java/com/talq2me/baerened/TrainerMapTaskMerge.kt  -  prepareFromDbStrict.
+
+-- BaerenEd: Today's visible photo-chore rows from user_data.photo_chores (trainer map).
+-- Same day filters as af_get_tasks_required (disable / hidedays / displayDays / showdays).
+-- POST /rest/v1/rpc/af_get_tasks_photo_chores {"p_profile":"AM"}
+
+CREATE OR REPLACE FUNCTION af_get_tasks_photo_chores(p_profile text)
+RETURNS TABLE (
+  task_name text,
+  chore_id text,
+  description text,
+  reward_cash numeric,
+  completion_status text,
+  berry_value int,
+  mins_value int,
+  launch text,
+  url text,
+  web_game boolean,
+  chrome_page boolean,
+  video_sequence text,
+  playlist_id text,
+  total_questions int,
+  reward_id text,
+  easy boolean,
+  easydays text,
+  harddays text,
+  extremedays text,
+  block_outlines boolean,
+  is_checklist boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH params AS (
+    SELECT
+      COALESCE(ud.photo_chores, '{}'::jsonb) AS v_chores,
+      lower(to_char((now() AT TIME ZONE 'America/Toronto'), 'Dy')) AS v_today_short,
+      (now() AT TIME ZONE 'America/Toronto')::date AS v_today_date
+    FROM (SELECT 1) AS _one
+    LEFT JOIN user_data ud ON ud.profile = p_profile
+  ),
+  visible AS (
+    SELECT
+      COALESCE(NULLIF(TRIM(e.value->>'title'), ''), e.key::text) AS task_name,
+      e.key::text AS chore_id,
+      (e.value->>'description')::text AS description,
+      COALESCE((e.value->>'rewardCash')::numeric, 0) AS reward_cash,
+      COALESCE(e.value->>'status', 'incomplete')::text AS completion_status,
+      COALESCE(NULLIF(TRIM(e.value->>'launch'), ''), 'chorePhoto') AS launch
+    FROM params p
+    CROSS JOIN jsonb_each(p.v_chores) AS e(key, value)
+    WHERE
+      NOT (
+        NULLIF(TRIM(COALESCE(e.value->>'disable', '')), '') IS NOT NULL
+        AND to_date(e.value->>'disable', 'Mon DD, YYYY') IS NOT NULL
+        AND p.v_today_date < to_date(e.value->>'disable', 'Mon DD, YYYY')
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest(string_to_array(lower(replace(COALESCE(e.value->>'hidedays', ''), ' ', '')), ',')) AS d(day_token)
+        WHERE d.day_token = p.v_today_short
+      )
+      AND (
+        NULLIF(TRIM(COALESCE(e.value->>'displayDays', '')), '') IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM unnest(string_to_array(lower(replace(COALESCE(e.value->>'displayDays', ''), ' ', '')), ',')) AS d(day_token)
+          WHERE d.day_token = p.v_today_short
+        )
+      )
+      AND (
+        NULLIF(TRIM(COALESCE(e.value->>'displayDays', '')), '') IS NOT NULL
+        OR NULLIF(TRIM(COALESCE(e.value->>'showdays', '')), '') IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM unnest(string_to_array(lower(replace(COALESCE(e.value->>'showdays', ''), ' ', '')), ',')) AS d(day_token)
+          WHERE d.day_token = p.v_today_short
+        )
+      )
+  )
+  SELECT
+    v.task_name,
+    v.chore_id,
+    v.description,
+    v.reward_cash,
+    v.completion_status,
+    0 AS berry_value,
+    0 AS mins_value,
+    v.launch,
+    NULL::text AS url,
+    false AS web_game,
+    false AS chrome_page,
+    NULL::text AS video_sequence,
+    NULL::text AS playlist_id,
+    NULL::int AS total_questions,
+    NULL::text AS reward_id,
+    false AS easy,
+    NULL::text AS easydays,
+    NULL::text AS harddays,
+    NULL::text AS extremedays,
+    false AS block_outlines,
+    false AS is_checklist
+  FROM visible v
+  ORDER BY v.task_name;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_get_tasks_photo_chores(text) TO anon, authenticated, service_role;

--- a/sql/af_grant_chore_reward.sql
+++ b/sql/af_grant_chore_reward.sql
@@ -1,0 +1,81 @@
+-- Call sites (BaerenEd reports, this repo):
+--   reports/daily_progress_report.html  -  parent Yes / edit amount then Yes.
+
+-- BaerenEd: Credit kid_bank_balance for one chore photo (image_uploads.task key).
+-- Idempotent: a second grant for the same profile+task_key does not add cash again.
+-- POST /rest/v1/rpc/af_grant_chore_reward
+--   {"p_profile":"AM","p_task_key":"chore_unload_dishwasher_2026-08-19","p_amount":2.00}
+
+CREATE OR REPLACE FUNCTION af_grant_chore_reward(
+  p_profile text,
+  p_task_key text,
+  p_amount numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  img image_uploads%ROWTYPE;
+  add_amount numeric;
+  new_balance numeric;
+BEGIN
+  IF NULLIF(TRIM(COALESCE(p_profile, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: p_profile is required';
+  END IF;
+  IF NULLIF(TRIM(COALESCE(p_task_key, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: p_task_key is required';
+  END IF;
+  IF p_amount IS NULL OR p_amount < 0 THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: p_amount must be >= 0';
+  END IF;
+
+  add_amount := ROUND(p_amount, 2);
+
+  SELECT * INTO img
+  FROM image_uploads
+  WHERE profile = p_profile AND task = p_task_key
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: no image for profile % task %', p_profile, p_task_key;
+  END IF;
+
+  IF COALESCE(img.reward_granted, false) THEN
+    SELECT COALESCE(kid_bank_balance, 0) INTO new_balance FROM user_data WHERE profile = p_profile;
+    RETURN jsonb_build_object(
+      'granted', false,
+      'already_granted', true,
+      'granted_amount', img.granted_amount,
+      'kid_bank_balance', COALESCE(new_balance, 0)
+    );
+  END IF;
+
+  UPDATE user_data
+  SET
+    kid_bank_balance = ROUND(COALESCE(kid_bank_balance, 0) + add_amount, 2),
+    last_updated = (NOW() AT TIME ZONE 'America/Toronto')
+  WHERE profile = p_profile
+  RETURNING COALESCE(kid_bank_balance, 0) INTO new_balance;
+
+  IF new_balance IS NULL THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: unknown profile %', p_profile;
+  END IF;
+
+  UPDATE image_uploads
+  SET
+    reward_granted = true,
+    granted_amount = add_amount
+  WHERE profile = p_profile AND task = p_task_key;
+
+  RETURN jsonb_build_object(
+    'granted', true,
+    'already_granted', false,
+    'granted_amount', add_amount,
+    'kid_bank_balance', new_balance
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_grant_chore_reward(text, text, numeric) TO anon, authenticated, service_role;

--- a/sql/af_update_tasks_from_config_photo_chores.sql
+++ b/sql/af_update_tasks_from_config_photo_chores.sql
@@ -1,0 +1,67 @@
+-- Call sites (BaerenEd Android, this repo):
+--   app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt  -  invokeAfUpdatePhotoChoresFromConfig.
+--   app/src/main/java/com/talq2me/baerened/DbProfileSessionLoader.kt  -  chained after profile load / config refresh.
+-- Invoked from (PostgreSQL, this repo sql/):
+--   af_daily_reset.sql
+
+-- BaerenEd: Merge GitHub Pages profile config section id "chores" into user_data.photo_chores.
+-- Keyed by chore id. Preserves today's status on merge. Does not grant cash, berries, or minutes.
+-- POST /rest/v1/rpc/af_update_tasks_from_config_photo_chores {"p_profile":"AM","p_config_json":{...}}
+
+CREATE OR REPLACE FUNCTION af_update_tasks_from_config_photo_chores(p_profile text, p_config_json jsonb DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  github_url text := 'https://talq2me.github.io/BaerenEd-Android-App/app/src/main/assets/config/' || p_profile || '_config.json';
+  config_json jsonb;
+  http_status int;
+  existing_chores jsonb;
+  merged_chores jsonb;
+BEGIN
+  IF p_config_json IS NOT NULL AND p_config_json != 'null'::jsonb THEN
+    config_json := p_config_json;
+  ELSE
+    SELECT r.status, r.content::jsonb INTO http_status, config_json FROM http_get(github_url) r LIMIT 1;
+    IF http_status != 200 OR config_json IS NULL THEN
+      RAISE WARNING 'af_update_tasks_from_config_photo_chores: failed to fetch config for %', p_profile;
+      RETURN;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(photo_chores, '{}'::jsonb) INTO existing_chores FROM user_data WHERE profile = p_profile;
+
+  SELECT COALESCE(
+    (
+      SELECT jsonb_object_agg(
+        t->>'id',
+        jsonb_build_object(
+          'status', COALESCE(existing_chores->(t->>'id')->>'status', 'incomplete'),
+          'title', t->>'title',
+          'description', t->>'description',
+          'rewardCash', t->'rewardCash',
+          'launch', COALESCE(NULLIF(TRIM(t->>'launch'), ''), 'chorePhoto'),
+          'showdays', t->>'showdays',
+          'hidedays', t->>'hidedays',
+          'displayDays', t->>'displayDays',
+          'disable', t->>'disable'
+        )
+      )
+      FROM jsonb_array_elements(config_json->'sections') AS sec,
+           jsonb_array_elements(COALESCE(sec->'tasks', '[]'::jsonb)) AS t
+      WHERE sec->>'id' = 'chores'
+        AND NULLIF(TRIM(COALESCE(t->>'id', '')), '') IS NOT NULL
+    ),
+    '{}'::jsonb
+  ) INTO merged_chores;
+
+  UPDATE user_data SET
+    photo_chores = merged_chores,
+    last_updated = (NOW() AT TIME ZONE 'America/Toronto')
+  WHERE profile = p_profile;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_update_tasks_from_config_photo_chores(text, jsonb) TO anon, authenticated, service_role;

--- a/sql/af_update_tasks_photo_chores.sql
+++ b/sql/af_update_tasks_photo_chores.sql
@@ -1,0 +1,39 @@
+-- Call sites (BaerenEd Android, this repo):
+--   app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt  -  invokeAfUpdatePhotoChore.
+--   app/src/main/java/com/talq2me/baerened/ChorePhotoActivity.kt  -  after image upload.
+
+-- BaerenEd: Mark a photo chore complete by chore id. Does not grant berries, minutes, coins, or cash.
+-- POST /rest/v1/rpc/af_update_tasks_photo_chores {"p_profile":"AM","p_chore_id":"unload_dishwasher"}
+
+CREATE OR REPLACE FUNCTION af_update_tasks_photo_chores(
+  p_profile text,
+  p_chore_id text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  cur jsonb;
+  existing jsonb;
+BEGIN
+  IF NULLIF(TRIM(COALESCE(p_chore_id, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'af_update_tasks_photo_chores: p_chore_id is required';
+  END IF;
+
+  SELECT COALESCE(photo_chores, '{}'::jsonb) INTO cur FROM user_data WHERE profile = p_profile;
+  existing := cur->p_chore_id;
+  IF existing IS NULL OR existing = 'null'::jsonb THEN
+    RAISE EXCEPTION 'af_update_tasks_photo_chores: unknown chore_id % for profile %', p_chore_id, p_profile;
+  END IF;
+
+  UPDATE user_data
+  SET
+    photo_chores = jsonb_set(cur, ARRAY[p_chore_id], existing || jsonb_build_object('status', 'complete'), true),
+    last_updated = (NOW() AT TIME ZONE 'America/Toronto')
+  WHERE profile = p_profile;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_update_tasks_photo_chores(text, text) TO anon, authenticated, service_role;

--- a/sql/af_upsert_user_data_columns.sql
+++ b/sql/af_upsert_user_data_columns.sql
@@ -34,6 +34,7 @@ BEGIN
       WHEN p_columns ? 'last_coins_payout_at' AND NULLIF(trim(p_columns->>'last_coins_payout_at'), '') IS NULL THEN NULL
       ELSE last_coins_payout_at END,
     chores = CASE WHEN p_columns ? 'chores' THEN (p_columns->'chores')::jsonb ELSE chores END,
+    photo_chores = CASE WHEN p_columns ? 'photo_chores' THEN (p_columns->'photo_chores')::jsonb ELSE photo_chores END,
     pokemon_unlocked = CASE WHEN p_columns ? 'pokemon_unlocked' THEN (p_columns->>'pokemon_unlocked')::int ELSE pokemon_unlocked END,
     game_indices = CASE WHEN p_columns ? 'game_indices' THEN (p_columns->'game_indices')::jsonb ELSE game_indices END,
     reward_time_expiry = CASE WHEN p_columns ? 'reward_time_expiry' AND NULLIF(trim(p_columns->>'reward_time_expiry'), '') IS NOT NULL

--- a/sql/regen_deploy_all_functions.ps1
+++ b/sql/regen_deploy_all_functions.ps1
@@ -10,6 +10,8 @@ $files = @(
 
   "af_update_tasks_from_config_chores.sql",
 
+  "af_update_tasks_from_config_photo_chores.sql",
+
   "af_update_tasks_from_config_practice.sql",
 
   "af_update_tasks_from_config_bonus.sql",
@@ -25,6 +27,8 @@ $files = @(
   "af_get_tasks_practice.sql",
 
   "af_get_tasks_bonus.sql",
+
+  "af_get_tasks_photo_chores.sql",
 
   "af_get_battle_hub_counts.sql",
 
@@ -52,6 +56,8 @@ $files = @(
 
   "af_upsert_image_upload.sql",
 
+  "af_grant_chore_reward.sql",
+
   "af_delete_image_uploads_ilike.sql",
 
   "af_get_image_upload_id.sql",
@@ -73,6 +79,8 @@ $files = @(
   "af_update_tasks_checklist_items.sql",
 
   "af_update_tasks_chores.sql",
+
+  "af_update_tasks_photo_chores.sql",
 
   "af_update_game_index.sql",
 

--- a/sql/supabase_functions_create.sql
+++ b/sql/supabase_functions_create.sql
@@ -25,11 +25,13 @@ DROP FUNCTION IF EXISTS af_get_settings_last_updated();
 DROP FUNCTION IF EXISTS af_get_settings_row();
 DROP FUNCTION IF EXISTS af_get_stars_to_minutes(int);
 DROP FUNCTION IF EXISTS af_get_tasks_bonus(text);
+DROP FUNCTION IF EXISTS af_get_tasks_photo_chores(text);
 DROP FUNCTION IF EXISTS af_get_tasks_practice(text);
 DROP FUNCTION IF EXISTS af_get_tasks_required(text);
 DROP FUNCTION IF EXISTS af_get_user_data(text);
 DROP FUNCTION IF EXISTS af_get_user_last_reset(text);
 DROP FUNCTION IF EXISTS af_get_user_last_updated(text);
+DROP FUNCTION IF EXISTS af_grant_chore_reward(text, text, numeric);
 DROP FUNCTION IF EXISTS af_insert_user_data_profile(text);
 DROP FUNCTION IF EXISTS af_log_behavior(text, text, text);
 DROP FUNCTION IF EXISTS af_maybe_advance_spelling_pools(text);
@@ -49,8 +51,10 @@ DROP FUNCTION IF EXISTS af_update_tasks_chores(text, int, boolean);
 DROP FUNCTION IF EXISTS af_update_tasks_from_config_bonus(text, jsonb);
 DROP FUNCTION IF EXISTS af_update_tasks_from_config_checklist_items(text, jsonb);
 DROP FUNCTION IF EXISTS af_update_tasks_from_config_chores(text, jsonb);
+DROP FUNCTION IF EXISTS af_update_tasks_from_config_photo_chores(text, jsonb);
 DROP FUNCTION IF EXISTS af_update_tasks_from_config_practice(text, jsonb);
 DROP FUNCTION IF EXISTS af_update_tasks_from_config_required(text, jsonb);
+DROP FUNCTION IF EXISTS af_update_tasks_photo_chores(text, text);
 DROP FUNCTION IF EXISTS af_update_tasks_practice(text, text, int, int, int, int, int);
 DROP FUNCTION IF EXISTS af_update_tasks_required(text, text, text, int, int, int);
 DROP FUNCTION IF EXISTS af_upsert_device(text, text, text, text, text, text, text, boolean);
@@ -199,6 +203,78 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION af_update_tasks_from_config_chores(text, jsonb) TO anon, authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
+-- FILE: af_update_tasks_from_config_photo_chores.sql
+-- -----------------------------------------------------------------------------
+-- Call sites (BaerenEd Android, this repo):
+--   app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt  -  invokeAfUpdatePhotoChoresFromConfig.
+--   app/src/main/java/com/talq2me/baerened/DbProfileSessionLoader.kt  -  chained after profile load / config refresh.
+-- Invoked from (PostgreSQL, this repo sql/):
+--   af_daily_reset.sql
+
+-- BaerenEd: Merge GitHub Pages profile config section id "chores" into user_data.photo_chores.
+-- Keyed by chore id. Preserves today's status on merge. Does not grant cash, berries, or minutes.
+-- POST /rest/v1/rpc/af_update_tasks_from_config_photo_chores {"p_profile":"AM","p_config_json":{...}}
+
+CREATE OR REPLACE FUNCTION af_update_tasks_from_config_photo_chores(p_profile text, p_config_json jsonb DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  github_url text := 'https://talq2me.github.io/BaerenEd-Android-App/app/src/main/assets/config/' || p_profile || '_config.json';
+  config_json jsonb;
+  http_status int;
+  existing_chores jsonb;
+  merged_chores jsonb;
+BEGIN
+  IF p_config_json IS NOT NULL AND p_config_json != 'null'::jsonb THEN
+    config_json := p_config_json;
+  ELSE
+    SELECT r.status, r.content::jsonb INTO http_status, config_json FROM http_get(github_url) r LIMIT 1;
+    IF http_status != 200 OR config_json IS NULL THEN
+      RAISE WARNING 'af_update_tasks_from_config_photo_chores: failed to fetch config for %', p_profile;
+      RETURN;
+    END IF;
+  END IF;
+
+  SELECT COALESCE(photo_chores, '{}'::jsonb) INTO existing_chores FROM user_data WHERE profile = p_profile;
+
+  SELECT COALESCE(
+    (
+      SELECT jsonb_object_agg(
+        t->>'id',
+        jsonb_build_object(
+          'status', COALESCE(existing_chores->(t->>'id')->>'status', 'incomplete'),
+          'title', t->>'title',
+          'description', t->>'description',
+          'rewardCash', t->'rewardCash',
+          'launch', COALESCE(NULLIF(TRIM(t->>'launch'), ''), 'chorePhoto'),
+          'showdays', t->>'showdays',
+          'hidedays', t->>'hidedays',
+          'displayDays', t->>'displayDays',
+          'disable', t->>'disable'
+        )
+      )
+      FROM jsonb_array_elements(config_json->'sections') AS sec,
+           jsonb_array_elements(COALESCE(sec->'tasks', '[]'::jsonb)) AS t
+      WHERE sec->>'id' = 'chores'
+        AND NULLIF(TRIM(COALESCE(t->>'id', '')), '') IS NOT NULL
+    ),
+    '{}'::jsonb
+  ) INTO merged_chores;
+
+  UPDATE user_data SET
+    photo_chores = merged_chores,
+    last_updated = (NOW() AT TIME ZONE 'America/Toronto')
+  WHERE profile = p_profile;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_update_tasks_from_config_photo_chores(text, jsonb) TO anon, authenticated, service_role;
 
 
 -- -----------------------------------------------------------------------------
@@ -576,7 +652,7 @@ GRANT EXECUTE ON FUNCTION af_update_tasks_from_config_required(text, jsonb) TO a
 
 -- BaerenEd: Daily reset applied at read time (AF = "at fetch").
 -- Call this before reading user_data so the row for the given profile with last_reset date not equal to today (Toronto time)
--- gets reset: blank required_tasks, checklist_items, practice_tasks, berries_earned, banked_mins, chores;
+-- gets reset: blank required_tasks, checklist_items, practice_tasks, berries_earned, banked_mins, chores, photo_chores;
 -- set last_reset and last_updated to now() in America/Toronto. Does not change coins_earned, pokemon_unlocked, game_indices.
 -- When a reset row was updated (FOUND), repopulates task/chore columns from GitHub via af_update_*
 -- (full implementations are in the per-function af_update_* files in sql/).
@@ -605,7 +681,8 @@ BEGIN
     banked_mins = 0,
     reward_time_expiry = NULL,
     prize_unlocked = NULL,
-    chores = '[]'::jsonb
+    chores = '[]'::jsonb,
+    photo_chores = '{}'::jsonb
   WHERE profile = p_profile
     AND (last_reset IS NULL OR last_reset::date IS DISTINCT FROM today_est);
 
@@ -614,6 +691,7 @@ BEGIN
     PERFORM af_update_tasks_from_config_practice(p_profile);
     PERFORM af_update_tasks_from_config_bonus(p_profile);
     PERFORM af_update_tasks_from_config_chores(p_profile);
+    PERFORM af_update_tasks_from_config_photo_chores(p_profile);
   END IF;
 END;
 $$;
@@ -1146,6 +1224,122 @@ GRANT EXECUTE ON FUNCTION af_get_tasks_bonus(text) TO anon, authenticated, servi
 
 
 -- -----------------------------------------------------------------------------
+-- FILE: af_get_tasks_photo_chores.sql
+-- -----------------------------------------------------------------------------
+-- Call sites (BaerenEd Android, this repo):
+--   app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt  -  invokeAfGetPhotoChoreTasksRows.
+--   app/src/main/java/com/talq2me/baerened/TrainerMapTaskMerge.kt  -  prepareFromDbStrict.
+
+-- BaerenEd: Today's visible photo-chore rows from user_data.photo_chores (trainer map).
+-- Same day filters as af_get_tasks_required (disable / hidedays / displayDays / showdays).
+-- POST /rest/v1/rpc/af_get_tasks_photo_chores {"p_profile":"AM"}
+
+CREATE OR REPLACE FUNCTION af_get_tasks_photo_chores(p_profile text)
+RETURNS TABLE (
+  task_name text,
+  chore_id text,
+  description text,
+  reward_cash numeric,
+  completion_status text,
+  berry_value int,
+  mins_value int,
+  launch text,
+  url text,
+  web_game boolean,
+  chrome_page boolean,
+  video_sequence text,
+  playlist_id text,
+  total_questions int,
+  reward_id text,
+  easy boolean,
+  easydays text,
+  harddays text,
+  extremedays text,
+  block_outlines boolean,
+  is_checklist boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH params AS (
+    SELECT
+      COALESCE(ud.photo_chores, '{}'::jsonb) AS v_chores,
+      lower(to_char((now() AT TIME ZONE 'America/Toronto'), 'Dy')) AS v_today_short,
+      (now() AT TIME ZONE 'America/Toronto')::date AS v_today_date
+    FROM (SELECT 1) AS _one
+    LEFT JOIN user_data ud ON ud.profile = p_profile
+  ),
+  visible AS (
+    SELECT
+      COALESCE(NULLIF(TRIM(e.value->>'title'), ''), e.key::text) AS task_name,
+      e.key::text AS chore_id,
+      (e.value->>'description')::text AS description,
+      COALESCE((e.value->>'rewardCash')::numeric, 0) AS reward_cash,
+      COALESCE(e.value->>'status', 'incomplete')::text AS completion_status,
+      COALESCE(NULLIF(TRIM(e.value->>'launch'), ''), 'chorePhoto') AS launch
+    FROM params p
+    CROSS JOIN jsonb_each(p.v_chores) AS e(key, value)
+    WHERE
+      NOT (
+        NULLIF(TRIM(COALESCE(e.value->>'disable', '')), '') IS NOT NULL
+        AND to_date(e.value->>'disable', 'Mon DD, YYYY') IS NOT NULL
+        AND p.v_today_date < to_date(e.value->>'disable', 'Mon DD, YYYY')
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM unnest(string_to_array(lower(replace(COALESCE(e.value->>'hidedays', ''), ' ', '')), ',')) AS d(day_token)
+        WHERE d.day_token = p.v_today_short
+      )
+      AND (
+        NULLIF(TRIM(COALESCE(e.value->>'displayDays', '')), '') IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM unnest(string_to_array(lower(replace(COALESCE(e.value->>'displayDays', ''), ' ', '')), ',')) AS d(day_token)
+          WHERE d.day_token = p.v_today_short
+        )
+      )
+      AND (
+        NULLIF(TRIM(COALESCE(e.value->>'displayDays', '')), '') IS NOT NULL
+        OR NULLIF(TRIM(COALESCE(e.value->>'showdays', '')), '') IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM unnest(string_to_array(lower(replace(COALESCE(e.value->>'showdays', ''), ' ', '')), ',')) AS d(day_token)
+          WHERE d.day_token = p.v_today_short
+        )
+      )
+  )
+  SELECT
+    v.task_name,
+    v.chore_id,
+    v.description,
+    v.reward_cash,
+    v.completion_status,
+    0 AS berry_value,
+    0 AS mins_value,
+    v.launch,
+    NULL::text AS url,
+    false AS web_game,
+    false AS chrome_page,
+    NULL::text AS video_sequence,
+    NULL::text AS playlist_id,
+    NULL::int AS total_questions,
+    NULL::text AS reward_id,
+    false AS easy,
+    NULL::text AS easydays,
+    NULL::text AS harddays,
+    NULL::text AS extremedays,
+    false AS block_outlines,
+    false AS is_checklist
+  FROM visible v
+  ORDER BY v.task_name;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_get_tasks_photo_chores(text) TO anon, authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
 -- FILE: af_get_battle_hub_counts.sql
 -- -----------------------------------------------------------------------------
 -- Call sites (BaerenEd Android, this repo):
@@ -1374,6 +1568,7 @@ BEGIN
       WHEN p_columns ? 'last_coins_payout_at' AND NULLIF(trim(p_columns->>'last_coins_payout_at'), '') IS NULL THEN NULL
       ELSE last_coins_payout_at END,
     chores = CASE WHEN p_columns ? 'chores' THEN (p_columns->'chores')::jsonb ELSE chores END,
+    photo_chores = CASE WHEN p_columns ? 'photo_chores' THEN (p_columns->'photo_chores')::jsonb ELSE photo_chores END,
     pokemon_unlocked = CASE WHEN p_columns ? 'pokemon_unlocked' THEN (p_columns->>'pokemon_unlocked')::int ELSE pokemon_unlocked END,
     game_indices = CASE WHEN p_columns ? 'game_indices' THEN (p_columns->'game_indices')::jsonb ELSE game_indices END,
     reward_time_expiry = CASE WHEN p_columns ? 'reward_time_expiry' AND NULLIF(trim(p_columns->>'reward_time_expiry'), '') IS NOT NULL
@@ -1675,6 +1870,92 @@ BEGIN
 END;
 $$;
 GRANT EXECUTE ON FUNCTION af_upsert_image_upload(text, text, text) TO anon, authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
+-- FILE: af_grant_chore_reward.sql
+-- -----------------------------------------------------------------------------
+-- Call sites (BaerenEd reports, this repo):
+--   reports/daily_progress_report.html  -  parent Yes / edit amount then Yes.
+
+-- BaerenEd: Credit kid_bank_balance for one chore photo (image_uploads.task key).
+-- Idempotent: a second grant for the same profile+task_key does not add cash again.
+-- POST /rest/v1/rpc/af_grant_chore_reward
+--   {"p_profile":"AM","p_task_key":"chore_unload_dishwasher_2026-08-19","p_amount":2.00}
+
+CREATE OR REPLACE FUNCTION af_grant_chore_reward(
+  p_profile text,
+  p_task_key text,
+  p_amount numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  img image_uploads%ROWTYPE;
+  add_amount numeric;
+  new_balance numeric;
+BEGIN
+  IF NULLIF(TRIM(COALESCE(p_profile, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: p_profile is required';
+  END IF;
+  IF NULLIF(TRIM(COALESCE(p_task_key, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: p_task_key is required';
+  END IF;
+  IF p_amount IS NULL OR p_amount < 0 THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: p_amount must be >= 0';
+  END IF;
+
+  add_amount := ROUND(p_amount, 2);
+
+  SELECT * INTO img
+  FROM image_uploads
+  WHERE profile = p_profile AND task = p_task_key
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: no image for profile % task %', p_profile, p_task_key;
+  END IF;
+
+  IF COALESCE(img.reward_granted, false) THEN
+    SELECT COALESCE(kid_bank_balance, 0) INTO new_balance FROM user_data WHERE profile = p_profile;
+    RETURN jsonb_build_object(
+      'granted', false,
+      'already_granted', true,
+      'granted_amount', img.granted_amount,
+      'kid_bank_balance', COALESCE(new_balance, 0)
+    );
+  END IF;
+
+  UPDATE user_data
+  SET
+    kid_bank_balance = ROUND(COALESCE(kid_bank_balance, 0) + add_amount, 2),
+    last_updated = (NOW() AT TIME ZONE 'America/Toronto')
+  WHERE profile = p_profile
+  RETURNING COALESCE(kid_bank_balance, 0) INTO new_balance;
+
+  IF new_balance IS NULL THEN
+    RAISE EXCEPTION 'af_grant_chore_reward: unknown profile %', p_profile;
+  END IF;
+
+  UPDATE image_uploads
+  SET
+    reward_granted = true,
+    granted_amount = add_amount
+  WHERE profile = p_profile AND task = p_task_key;
+
+  RETURN jsonb_build_object(
+    'granted', true,
+    'already_granted', false,
+    'granted_amount', add_amount,
+    'kid_bank_balance', new_balance
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_grant_chore_reward(text, text, numeric) TO anon, authenticated, service_role;
 
 
 -- -----------------------------------------------------------------------------
@@ -2394,6 +2675,50 @@ GRANT EXECUTE ON FUNCTION af_update_tasks_chores(text, int, boolean) TO anon, au
 
 
 -- -----------------------------------------------------------------------------
+-- FILE: af_update_tasks_photo_chores.sql
+-- -----------------------------------------------------------------------------
+-- Call sites (BaerenEd Android, this repo):
+--   app/src/main/java/com/talq2me/baerened/SupabaseInterface.kt  -  invokeAfUpdatePhotoChore.
+--   app/src/main/java/com/talq2me/baerened/ChorePhotoActivity.kt  -  after image upload.
+
+-- BaerenEd: Mark a photo chore complete by chore id. Does not grant berries, minutes, coins, or cash.
+-- POST /rest/v1/rpc/af_update_tasks_photo_chores {"p_profile":"AM","p_chore_id":"unload_dishwasher"}
+
+CREATE OR REPLACE FUNCTION af_update_tasks_photo_chores(
+  p_profile text,
+  p_chore_id text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  cur jsonb;
+  existing jsonb;
+BEGIN
+  IF NULLIF(TRIM(COALESCE(p_chore_id, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'af_update_tasks_photo_chores: p_chore_id is required';
+  END IF;
+
+  SELECT COALESCE(photo_chores, '{}'::jsonb) INTO cur FROM user_data WHERE profile = p_profile;
+  existing := cur->p_chore_id;
+  IF existing IS NULL OR existing = 'null'::jsonb THEN
+    RAISE EXCEPTION 'af_update_tasks_photo_chores: unknown chore_id % for profile %', p_chore_id, p_profile;
+  END IF;
+
+  UPDATE user_data
+  SET
+    photo_chores = jsonb_set(cur, ARRAY[p_chore_id], existing || jsonb_build_object('status', 'complete'), true),
+    last_updated = (NOW() AT TIME ZONE 'America/Toronto')
+  WHERE profile = p_profile;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION af_update_tasks_photo_chores(text, text) TO anon, authenticated, service_role;
+
+
+-- -----------------------------------------------------------------------------
 -- FILE: af_update_game_index.sql
 -- -----------------------------------------------------------------------------
 -- Call sites (BaerenEd Android, this repo):
@@ -3009,6 +3334,7 @@ $$;
 GRANT EXECUTE ON FUNCTION af_get_behavior_log(text, timestamp, timestamp) TO anon, authenticated, service_role;
 
 
+-- -----------------------------------------------------------------------------
 -- FILE: af_update_behavior_log_time.sql
 -- -----------------------------------------------------------------------------
 -- Call sites (reports):

--- a/sql/supabase_schema_create.sql
+++ b/sql/supabase_schema_create.sql
@@ -91,6 +91,11 @@ CREATE TABLE IF NOT EXISTS user_data (
     -- Chores 4 $$: JSONB array of { chore_id, description, coins_reward, done }; done resets daily
     chores JSONB DEFAULT '[]'::jsonb,
 
+    -- Photo chores (trainer map): object keyed by chore id
+    -- { "unload_dishwasher": { "status": "incomplete"/"complete", "title", "description", "rewardCash", "launch", "displayDays", ... } }
+    -- status resets daily; photos in image_uploads are kept
+    photo_chores JSONB DEFAULT '{}'::jsonb,
+
     -- Pokemon data
     pokemon_unlocked INTEGER DEFAULT 0,
 
@@ -120,6 +125,9 @@ CREATE TABLE IF NOT EXISTS user_data (
 
 -- Create index on profile for faster lookups
 CREATE INDEX IF NOT EXISTS idx_user_data_profile ON user_data(profile);
+
+-- Existing DBs created before photo_chores: add the column without rebuilding user_data
+ALTER TABLE user_data ADD COLUMN IF NOT EXISTS photo_chores JSONB DEFAULT '{}'::jsonb;
 
 -- Enable Row Level Security (RLS) - adjust policies based on your security needs
 ALTER TABLE user_data ENABLE ROW LEVEL SECURITY;
@@ -317,16 +325,22 @@ CREATE POLICY "Allow all operations on devices" ON devices
 CREATE TABLE IF NOT EXISTS image_uploads (
     id BIGSERIAL PRIMARY KEY,
     profile TEXT NOT NULL, -- "AM" or "BM"
-    task TEXT NOT NULL, -- Task name (e.g., "englishSpellingJumblePhoto", "frenchSpellingJumblePhoto")
+    task TEXT NOT NULL, -- Task name (e.g., "englishSpellingJumblePhoto", "frenchSpellingJumblePhoto", "chore_{id}_{yyyy-MM-dd}")
     image TEXT NOT NULL, -- Base64 encoded image data
     capture_date_time TIMESTAMP(3) DEFAULT (NOW() AT TIME ZONE 'America/Toronto'), -- When the photo was taken/uploaded (Toronto time)
-    
+    reward_granted BOOLEAN DEFAULT false, -- Parent granted kid_bank_balance for this photo
+    granted_amount NUMERIC(12,2), -- Amount actually credited (may differ from config rewardCash)
+
     -- Unique task key per row; apps use distinct keys per word/day (retries overwrite same key only)
     UNIQUE(profile, task)
 );
 
 -- Create index on profile and task for faster lookups
 CREATE INDEX IF NOT EXISTS idx_image_uploads_profile_task ON image_uploads(profile, task);
+
+-- Existing DBs created before parent cash-grant columns
+ALTER TABLE image_uploads ADD COLUMN IF NOT EXISTS reward_granted BOOLEAN DEFAULT false;
+ALTER TABLE image_uploads ADD COLUMN IF NOT EXISTS granted_amount NUMERIC(12,2);
 
 -- Enable Row Level Security (RLS)
 ALTER TABLE image_uploads ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Kids can complete day-filtered photo chores from a dedicated trainer map. Parents review those photos on the daily progress report and can credit the configured cash amount (or an edited amount) to `kid_bank_balance`.

## Kid flow
- Battle Hub **Chores** opens `TrainingMapActivity` with `mapType=chores` instead of the checkbox coin list.
- Gyms come from the new `chores` section in `AM_config.json` / `BM_config.json` (`displayDays`, `rewardCash`).
- Tap a gym → chore instructions + camera. Submit uploads `image_uploads` with task key `chore_{id}_{yyyy-MM-dd}` (Toronto date) and marks `photo_chores` complete. No berries, minutes, or cash are granted on the tablet.

## Parent flow
- Daily progress report shows today’s chore photo thumbnails.
- Click for full size. On close, if not already paid: Yes / No / edit amount then Yes.
- `af_grant_chore_reward` adds cash to `kid_bank_balance` and is idempotent for that photo.

## Database
- New `user_data.photo_chores` JSONB (separate from checkbox `chores` / `coins_earned`).
- `image_uploads.reward_granted` and `granted_amount`.
- New RPCs: `af_update_tasks_from_config_photo_chores`, `af_get_tasks_photo_chores`, `af_update_tasks_photo_chores`, `af_grant_chore_reward`.
- Daily reset blanks `photo_chores` then restores from GitHub Pages config. Photos are kept.

## Deploy note
Supabase MCP was not available in this environment, so the live database still needs the schema/RPC apply (`photo_chores` column, image grant columns, and the new functions from `sql/`).

The checkbox **Chores 4 coins** path is unchanged in the DB; it is just no longer the Battle Hub button destination.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a017ca-483d-7c9d-a92e-469853f0447b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a017ca-483d-7c9d-a92e-469853f0447b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

